### PR TITLE
MIGI-CS-001: verifiable core + RAG0SHOT code recall

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -20,14 +20,22 @@ jobs:
           test -f LICENSE
           test -f CONTRIBUTING.md
           test -f SECURITY.md
+          test -f Cargo.toml
           test -f docs/architecture/internal-operating-projects.md
           test -f docs/architecture/repository-roles.md
           test -f docs/roadmap/mirror-seed-mvp.md
           test -f docs/adr/README.md
           test -f provenance/dependencies.yaml
+          test -f provenance/code-formats.yaml
           test -f schemas/muef-event.v0.json
           test -f schemas/migi-receipt.v0.json
+          test -f schemas/migi-code-artifact.v0.json
+          test -f crates/migi-core/Cargo.toml
+          test -f crates/migi-recall/Cargo.toml
       - name: Validate JSON schemas parse
         run: |
           python3 -m json.tool schemas/muef-event.v0.json >/dev/null
           python3 -m json.tool schemas/migi-receipt.v0.json >/dev/null
+          python3 -m json.tool schemas/migi-code-artifact.v0.json >/dev/null
+      - name: Run Rust workspace tests
+        run: cargo test --workspace --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,7 @@
 members = [
     "crates/migi-core",
     "crates/migi-recall",
+    "crates/migi-chainlog",
+    "crates/migi-cambus",
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
-members = ["crates/migi-core"]
+members = [
+    "crates/migi-core",
+    "crates/migi-recall",
+]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/migi-core"]
+resolver = "2"

--- a/crates/migi-cambus/Cargo.toml
+++ b/crates/migi-cambus/Cargo.toml
@@ -9,3 +9,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+migi-chainlog = { path = "../migi-chainlog" }

--- a/crates/migi-cambus/Cargo.toml
+++ b/crates/migi-cambus/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "migi-cambus"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+migi-core = { path = "../migi-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/migi-cambus/src/lib.rs
+++ b/crates/migi-cambus/src/lib.rs
@@ -71,9 +71,6 @@ pub fn encode_packet(packet: &SymbolPacket) -> Result<Vec<u8>, CambusError> {
     if packet.protocol_version != CAMBUS_PROTOCOL_VERSION {
         return Err(CambusError::UnsupportedVersion(packet.protocol_version.clone()));
     }
-    if packet.qos.priority > 255 {
-        return Err(CambusError::InvalidPriority(packet.qos.priority));
-    }
     Ok(serde_json::to_vec(packet)?)
 }
 
@@ -136,8 +133,6 @@ pub enum CambusError {
     UnsupportedVersion(String),
     #[error("CAMbus frame exceeds maximum size: {0} bytes")]
     FrameTooLarge(usize),
-    #[error("invalid QoS priority: {0}")]
-    InvalidPriority(u8),
 }
 
 #[cfg(test)]

--- a/crates/migi-cambus/src/lib.rs
+++ b/crates/migi-cambus/src/lib.rs
@@ -1,0 +1,185 @@
+use migi_core::MuefEvent;
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+use thiserror::Error;
+use uuid::Uuid;
+
+pub const CAMBUS_PROTOCOL_VERSION: &str = "cambus.v0";
+pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryClass {
+    BestEffort,
+    Reliable,
+    Control,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QosProfile {
+    pub delivery: DeliveryClass,
+    pub priority: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_latency_ms: Option<u64>,
+    pub local_only: bool,
+}
+
+impl Default for QosProfile {
+    fn default() -> Self {
+        Self {
+            delivery: DeliveryClass::Reliable,
+            priority: 128,
+            max_latency_ms: None,
+            local_only: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolPacket {
+    pub protocol_version: String,
+    pub packet_id: String,
+    pub correlation_id: String,
+    pub source_node: String,
+    pub destination_node: String,
+    pub qos: QosProfile,
+    pub event: MuefEvent,
+}
+
+impl SymbolPacket {
+    pub fn new(
+        source_node: impl Into<String>,
+        destination_node: impl Into<String>,
+        event: MuefEvent,
+    ) -> Self {
+        let packet_id = Uuid::new_v4().to_string();
+        Self {
+            protocol_version: CAMBUS_PROTOCOL_VERSION.into(),
+            correlation_id: packet_id.clone(),
+            packet_id,
+            source_node: source_node.into(),
+            destination_node: destination_node.into(),
+            qos: QosProfile::default(),
+            event,
+        }
+    }
+}
+
+pub fn encode_packet(packet: &SymbolPacket) -> Result<Vec<u8>, CambusError> {
+    if packet.protocol_version != CAMBUS_PROTOCOL_VERSION {
+        return Err(CambusError::UnsupportedVersion(packet.protocol_version.clone()));
+    }
+    if packet.qos.priority > 255 {
+        return Err(CambusError::InvalidPriority(packet.qos.priority));
+    }
+    Ok(serde_json::to_vec(packet)?)
+}
+
+pub fn decode_packet(bytes: &[u8]) -> Result<SymbolPacket, CambusError> {
+    if bytes.len() > DEFAULT_MAX_FRAME_BYTES {
+        return Err(CambusError::FrameTooLarge(bytes.len()));
+    }
+    let packet: SymbolPacket = serde_json::from_slice(bytes)?;
+    if packet.protocol_version != CAMBUS_PROTOCOL_VERSION {
+        return Err(CambusError::UnsupportedVersion(packet.protocol_version));
+    }
+    Ok(packet)
+}
+
+/// Length-prefixed CAMbus v0 frame over an arbitrary Read/Write stream.
+/// The wire envelope is transport-neutral; TCP is only the first adapter.
+pub fn write_frame<W: Write>(writer: &mut W, packet: &SymbolPacket) -> Result<(), CambusError> {
+    let payload = encode_packet(packet)?;
+    if payload.len() > DEFAULT_MAX_FRAME_BYTES {
+        return Err(CambusError::FrameTooLarge(payload.len()));
+    }
+    let length = u32::try_from(payload.len()).map_err(|_| CambusError::FrameTooLarge(payload.len()))?;
+    writer.write_all(&length.to_be_bytes())?;
+    writer.write_all(&payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+pub fn read_frame<R: Read>(reader: &mut R) -> Result<SymbolPacket, CambusError> {
+    let mut length_bytes = [0u8; 4];
+    reader.read_exact(&mut length_bytes)?;
+    let length = u32::from_be_bytes(length_bytes) as usize;
+    if length > DEFAULT_MAX_FRAME_BYTES {
+        return Err(CambusError::FrameTooLarge(length));
+    }
+    let mut payload = vec![0u8; length];
+    reader.read_exact(&mut payload)?;
+    decode_packet(&payload)
+}
+
+pub fn send_tcp(address: &str, packet: &SymbolPacket) -> Result<(), CambusError> {
+    let mut stream = TcpStream::connect(address)?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    write_frame(&mut stream, packet)
+}
+
+pub fn receive_one_tcp(listener: &TcpListener) -> Result<SymbolPacket, CambusError> {
+    let (mut stream, _) = listener.accept()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    read_frame(&mut stream)
+}
+
+#[derive(Debug, Error)]
+pub enum CambusError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported CAMbus protocol version: {0}")]
+    UnsupportedVersion(String),
+    #[error("CAMbus frame exceeds maximum size: {0} bytes")]
+    FrameTooLarge(usize),
+    #[error("invalid QoS priority: {0}")]
+    InvalidPriority(u8),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use migi_core::{Actor, ActorType, SourceClass};
+    use std::thread;
+
+    fn test_event() -> MuefEvent {
+        let actor = Actor { actor_type: ActorType::Service, id: "node-a".into() };
+        let mut event = MuefEvent::new("migi.signal.test", actor, SourceClass::Original);
+        event.payload.insert("message".into(), serde_json::json!("hello-node-b"));
+        event
+    }
+
+    #[test]
+    fn packet_round_trip_preserves_event_identity() {
+        let packet = SymbolPacket::new("node-a", "node-b", test_event());
+        let bytes = encode_packet(&packet).unwrap();
+        let decoded = decode_packet(&bytes).unwrap();
+        assert_eq!(decoded.packet_id, packet.packet_id);
+        assert_eq!(decoded.event.event_id, packet.event.event_id);
+        assert_eq!(decoded.destination_node, "node-b");
+    }
+
+    #[test]
+    fn two_nodes_exchange_muef_event_over_tcp() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let receiver = thread::spawn(move || {
+            let packet = receive_one_tcp(&listener).unwrap();
+            assert_eq!(packet.source_node, "node-a");
+            assert_eq!(packet.destination_node, "node-b");
+            assert_eq!(packet.event.event_type, "migi.signal.test");
+            packet.event.event_id
+        });
+
+        let packet = SymbolPacket::new("node-a", "node-b", test_event());
+        let expected_event_id = packet.event.event_id.clone();
+        send_tcp(&address.to_string(), &packet).unwrap();
+
+        assert_eq!(receiver.join().unwrap(), expected_event_id);
+    }
+}

--- a/crates/migi-cambus/tests/verifiable_signal_loop.rs
+++ b/crates/migi-cambus/tests/verifiable_signal_loop.rs
@@ -21,7 +21,7 @@ fn node_a_to_node_b_is_replayable_and_verifiable() {
         let observation = serde_json::json!({
             "accepted": true,
             "executed_by": "node-b",
-            "event_id": packet.event.event_id
+            "event_id": packet.event.event_id.clone()
         });
         let receipt = issue_receipt(
             &packet.event,

--- a/crates/migi-cambus/tests/verifiable_signal_loop.rs
+++ b/crates/migi-cambus/tests/verifiable_signal_loop.rs
@@ -1,0 +1,66 @@
+use migi_cambus::{receive_one_tcp, send_tcp, SymbolPacket};
+use migi_chainlog::{ChainLog, GENESIS_RECEIPT_REF};
+use migi_core::{issue_receipt, Actor, ActorType, Authority, MuefEvent, SourceClass, TreLogic};
+use std::net::TcpListener;
+use std::thread;
+
+#[test]
+fn node_a_to_node_b_is_replayable_and_verifiable() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+
+    let node_b = thread::spawn(move || {
+        let packet = receive_one_tcp(&listener).expect("node-b receives CAMbus packet");
+
+        let authority = Authority {
+            tre_logic: TreLogic::Proceed,
+            reason_code: "local_test_signal_allowed".into(),
+            consent_scope: Some("migi-cs-001".into()),
+        };
+
+        let observation = serde_json::json!({
+            "accepted": true,
+            "executed_by": "node-b",
+            "event_id": packet.event.event_id
+        });
+        let receipt = issue_receipt(
+            &packet.event,
+            authority,
+            &observation,
+            GENESIS_RECEIPT_REF,
+        )
+        .expect("node-b issues receipt");
+
+        let mut chainlog = ChainLog::open_memory().expect("chainlog opens");
+        chainlog
+            .append(packet.event, observation, receipt)
+            .expect("verified entry appends");
+        chainlog.verify().expect("chain verifies");
+        let replayed = chainlog.replay().expect("state replays");
+
+        (
+            chainlog.len().unwrap(),
+            replayed.values.get("mode").cloned(),
+            replayed.applied_entries,
+            replayed.head_receipt_id,
+        )
+    });
+
+    let actor = Actor {
+        actor_type: ActorType::Service,
+        id: "node-a".into(),
+    };
+    let mut event = MuefEvent::new("migi.state.patch", actor, SourceClass::Original);
+    event
+        .payload
+        .insert("state_patch".into(), serde_json::json!({"mode": "active"}));
+
+    let packet = SymbolPacket::new("node-a", "node-b", event);
+    send_tcp(&address.to_string(), &packet).expect("node-a sends CAMbus packet");
+
+    let (entries, mode, applied_entries, head_receipt) = node_b.join().unwrap();
+    assert_eq!(entries, 1);
+    assert_eq!(mode, Some(serde_json::json!("active")));
+    assert_eq!(applied_entries, 1);
+    assert!(head_receipt.is_some());
+}

--- a/crates/migi-chainlog/Cargo.toml
+++ b/crates/migi-chainlog/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "migi-chainlog"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+migi-core = { path = "../migi-core" }
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"

--- a/crates/migi-chainlog/src/lib.rs
+++ b/crates/migi-chainlog/src/lib.rs
@@ -1,0 +1,304 @@
+use migi_core::{sha256_json, MigiReceipt, MuefEvent};
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::Path;
+use thiserror::Error;
+
+pub const GENESIS_RECEIPT_REF: &str = "genesis";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChainEntry {
+    pub sequence: u64,
+    pub event: MuefEvent,
+    pub observation: Value,
+    pub receipt: MigiReceipt,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ReplayState {
+    pub values: BTreeMap<String, Value>,
+    pub applied_entries: u64,
+    pub head_receipt_id: Option<String>,
+}
+
+impl ReplayState {
+    /// Deterministic v0 state reducer.
+    /// If an event payload contains `state_patch`, each object key is applied
+    /// in sorted-map order. JSON null deletes the key; any other value sets it.
+    pub fn apply(&mut self, entry: &ChainEntry) {
+        if let Some(Value::Object(patch)) = entry.event.payload.get("state_patch") {
+            for (key, value) in patch {
+                if value.is_null() {
+                    self.values.remove(key);
+                } else {
+                    self.values.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        self.applied_entries += 1;
+        self.head_receipt_id = Some(entry.receipt.receipt_id.clone());
+    }
+}
+
+pub struct ChainLog {
+    conn: Connection,
+}
+
+impl ChainLog {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ChainLogError> {
+        let conn = Connection::open(path)?;
+        let log = Self { conn };
+        log.init()?;
+        Ok(log)
+    }
+
+    pub fn open_memory() -> Result<Self, ChainLogError> {
+        let conn = Connection::open_in_memory()?;
+        let log = Self { conn };
+        log.init()?;
+        Ok(log)
+    }
+
+    fn init(&self) -> Result<(), ChainLogError> {
+        self.conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE IF NOT EXISTS chainlog (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                receipt_id TEXT NOT NULL UNIQUE,
+                previous_receipt_ref TEXT NOT NULL,
+                event_json TEXT NOT NULL,
+                observation_json TEXT NOT NULL,
+                receipt_json TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_chainlog_receipt ON chainlog(receipt_id);
+             CREATE INDEX IF NOT EXISTS idx_chainlog_event ON chainlog(event_id);"
+        )?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> Result<u64, ChainLogError> {
+        Ok(self.conn.query_row("SELECT COUNT(*) FROM chainlog", [], |row| row.get::<_, u64>(0))?)
+    }
+
+    pub fn head_receipt_id(&self) -> Result<Option<String>, ChainLogError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT receipt_id FROM chainlog ORDER BY sequence DESC LIMIT 1"
+        )?;
+        let mut rows = stmt.query([])?;
+        Ok(match rows.next()? {
+            Some(row) => Some(row.get(0)?),
+            None => None,
+        })
+    }
+
+    pub fn expected_previous_receipt_ref(&self) -> Result<String, ChainLogError> {
+        Ok(self.head_receipt_id()?.unwrap_or_else(|| GENESIS_RECEIPT_REF.to_string()))
+    }
+
+    pub fn append(
+        &mut self,
+        event: MuefEvent,
+        observation: Value,
+        receipt: MigiReceipt,
+    ) -> Result<ChainEntry, ChainLogError> {
+        let expected_previous = self.expected_previous_receipt_ref()?;
+        verify_record(&event, &observation, &receipt, &expected_previous)?;
+
+        let event_json = serde_json::to_string(&event)?;
+        let observation_json = serde_json::to_string(&observation)?;
+        let receipt_json = serde_json::to_string(&receipt)?;
+
+        self.conn.execute(
+            "INSERT INTO chainlog (
+                event_id, receipt_id, previous_receipt_ref,
+                event_json, observation_json, receipt_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                event.event_id,
+                receipt.receipt_id,
+                receipt.previous_receipt_ref,
+                event_json,
+                observation_json,
+                receipt_json,
+            ],
+        )?;
+
+        let sequence = self.conn.last_insert_rowid() as u64;
+        Ok(ChainEntry { sequence, event, observation, receipt })
+    }
+
+    pub fn entries(&self) -> Result<Vec<ChainEntry>, ChainLogError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT sequence, event_json, observation_json, receipt_json
+             FROM chainlog ORDER BY sequence ASC"
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, u64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            let (sequence, event_json, observation_json, receipt_json) = row?;
+            entries.push(ChainEntry {
+                sequence,
+                event: serde_json::from_str(&event_json)?,
+                observation: serde_json::from_str(&observation_json)?,
+                receipt: serde_json::from_str(&receipt_json)?,
+            });
+        }
+        Ok(entries)
+    }
+
+    pub fn verify(&self) -> Result<(), ChainLogError> {
+        let entries = self.entries()?;
+        let mut previous = GENESIS_RECEIPT_REF.to_string();
+        for entry in entries {
+            verify_record(&entry.event, &entry.observation, &entry.receipt, &previous)?;
+            previous = entry.receipt.receipt_id;
+        }
+        Ok(())
+    }
+
+    pub fn replay(&self) -> Result<ReplayState, ChainLogError> {
+        self.verify()?;
+        let mut state = ReplayState::default();
+        for entry in self.entries()? {
+            state.apply(&entry);
+        }
+        Ok(state)
+    }
+}
+
+pub fn verify_record(
+    event: &MuefEvent,
+    observation: &Value,
+    receipt: &MigiReceipt,
+    expected_previous_receipt_ref: &str,
+) -> Result<(), ChainLogError> {
+    if receipt.event_id != event.event_id {
+        return Err(ChainLogError::EventReceiptMismatch);
+    }
+    if receipt.previous_receipt_ref != expected_previous_receipt_ref {
+        return Err(ChainLogError::BrokenParent {
+            expected: expected_previous_receipt_ref.to_string(),
+            actual: receipt.previous_receipt_ref.clone(),
+        });
+    }
+
+    let expected_input_hash = sha256_json(event);
+    let recorded_input_hash = receipt
+        .metadata
+        .get("input_hash")
+        .and_then(Value::as_str)
+        .ok_or(ChainLogError::MissingInputHash)?;
+    if recorded_input_hash != expected_input_hash {
+        return Err(ChainLogError::InputHashMismatch);
+    }
+
+    let expected_output_hash = sha256_json(observation);
+    if receipt.output_ref != expected_output_hash {
+        return Err(ChainLogError::OutputHashMismatch);
+    }
+
+    if let Some(recorded_output_hash) = receipt.metadata.get("output_hash").and_then(Value::as_str) {
+        if recorded_output_hash != expected_output_hash {
+            return Err(ChainLogError::OutputHashMismatch);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum ChainLogError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("receipt event_id does not match event")]
+    EventReceiptMismatch,
+    #[error("receipt parent mismatch: expected {expected}, got {actual}")]
+    BrokenParent { expected: String, actual: String },
+    #[error("receipt metadata is missing input_hash")]
+    MissingInputHash,
+    #[error("event input hash does not match receipt")]
+    InputHashMismatch,
+    #[error("observation output hash does not match receipt")]
+    OutputHashMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use migi_core::{issue_receipt, Actor, ActorType, Authority, SourceClass, TreLogic};
+
+    fn actor() -> Actor {
+        Actor { actor_type: ActorType::Service, id: "node-a".into() }
+    }
+
+    fn authority() -> Authority {
+        Authority {
+            tre_logic: TreLogic::Proceed,
+            reason_code: "test_allowed".into(),
+            consent_scope: Some("local-test".into()),
+        }
+    }
+
+    fn event_with_patch(key: &str, value: Value) -> MuefEvent {
+        let mut event = MuefEvent::new("migi.state.patch", actor(), SourceClass::Original);
+        event.payload.insert("state_patch".into(), serde_json::json!({key: value}));
+        event
+    }
+
+    #[test]
+    fn appends_verifies_and_replays_chain() {
+        let mut log = ChainLog::open_memory().unwrap();
+
+        let event1 = event_with_patch("mode", serde_json::json!("idle"));
+        let observation1 = serde_json::json!({"accepted": true, "state": "idle"});
+        let receipt1 = issue_receipt(&event1, authority(), &observation1, GENESIS_RECEIPT_REF).unwrap();
+        log.append(event1, observation1, receipt1).unwrap();
+
+        let event2 = event_with_patch("mode", serde_json::json!("active"));
+        let observation2 = serde_json::json!({"accepted": true, "state": "active"});
+        let previous = log.head_receipt_id().unwrap().unwrap();
+        let receipt2 = issue_receipt(&event2, authority(), &observation2, previous).unwrap();
+        log.append(event2, observation2, receipt2).unwrap();
+
+        assert_eq!(log.len().unwrap(), 2);
+        log.verify().unwrap();
+
+        let state = log.replay().unwrap();
+        assert_eq!(state.values.get("mode"), Some(&serde_json::json!("active")));
+        assert_eq!(state.applied_entries, 2);
+        assert!(state.head_receipt_id.is_some());
+    }
+
+    #[test]
+    fn rejects_broken_parent_chain() {
+        let mut log = ChainLog::open_memory().unwrap();
+        let event = event_with_patch("mode", serde_json::json!("idle"));
+        let observation = serde_json::json!({"accepted": true});
+        let receipt = issue_receipt(&event, authority(), &observation, "wrong-parent").unwrap();
+        let error = log.append(event, observation, receipt).unwrap_err();
+        assert!(matches!(error, ChainLogError::BrokenParent { .. }));
+    }
+
+    #[test]
+    fn rejects_tampered_observation() {
+        let event = event_with_patch("mode", serde_json::json!("idle"));
+        let original = serde_json::json!({"accepted": true});
+        let receipt = issue_receipt(&event, authority(), &original, GENESIS_RECEIPT_REF).unwrap();
+        let tampered = serde_json::json!({"accepted": false});
+        let error = verify_record(&event, &tampered, &receipt, GENESIS_RECEIPT_REF).unwrap_err();
+        assert!(matches!(error, ChainLogError::OutputHashMismatch));
+    }
+}

--- a/crates/migi-chainlog/src/lib.rs
+++ b/crates/migi-chainlog/src/lib.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 pub const GENESIS_RECEIPT_REF: &str = "genesis";
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainEntry {
     pub sequence: u64,
     pub event: MuefEvent,
@@ -25,8 +25,8 @@ pub struct ReplayState {
 
 impl ReplayState {
     /// Deterministic v0 state reducer.
-    /// If an event payload contains `state_patch`, each object key is applied
-    /// in sorted-map order. JSON null deletes the key; any other value sets it.
+    /// If an event payload contains `state_patch`, JSON null deletes a key;
+    /// any other value sets it. Only verified entries are replayed.
     pub fn apply(&mut self, entry: &ChainEntry) {
         if let Some(Value::Object(patch)) = entry.event.payload.get("state_patch") {
             for (key, value) in patch {
@@ -117,12 +117,12 @@ impl ChainLog {
                 event_json, observation_json, receipt_json
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
-                event.event_id,
-                receipt.receipt_id,
-                receipt.previous_receipt_ref,
-                event_json,
-                observation_json,
-                receipt_json,
+                &event.event_id,
+                &receipt.receipt_id,
+                &receipt.previous_receipt_ref,
+                &event_json,
+                &observation_json,
+                &receipt_json,
             ],
         )?;
 

--- a/crates/migi-core/Cargo.toml
+++ b/crates/migi-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "migi-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+uuid = { version = "1", features = ["v4", "serde"] }
+thiserror = "1"

--- a/crates/migi-core/README.md
+++ b/crates/migi-core/README.md
@@ -1,0 +1,23 @@
+# MIGI Core — MIGI-CS-001
+
+First executable foundation for the Verifiable Signal Loop.
+
+## Current primitives
+
+- `MuefEvent` — typed MIGI Unified Event Framework event.
+- `Authority` / `TreLogic` — `+1`, `0`, `-1` decision model.
+- `MigiReceipt` — provenance record linking an event, input hash, output hash, authority decision, and previous receipt.
+- `validate_event` — minimal v0 MUEF validation.
+- `sha256_json` — deterministic JSON hashing helper.
+
+## Lifecycle
+
+```text
+MUEF event → authority → execution → observation → MIGIReceipt
+```
+
+MIGI-CS-001 intentionally keeps transport and persistence out of this crate. Those will be added as separate layers so CAMbus/BEAM/ChainLog remain independently testable.
+
+## Status
+
+Experimental v0.1. The implementation follows the existing repository schemas; it is not yet a complete security boundary or distributed runtime.

--- a/crates/migi-core/src/lib.rs
+++ b/crates/migi-core/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Actor {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum SourceClass {
     Original,
     Observed,
@@ -95,26 +96,31 @@ pub struct MigiReceipt {
     pub output_ref: String,
     pub previous_receipt_ref: String,
     pub authority: Authority,
-    pub input_hash: String,
-    pub output_hash: String,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Error)]
 pub enum CoreError {
     #[error("event schema_version must be muef.v0")]
     InvalidSchemaVersion,
-    #[error("event_type must be namespaced, e.g. migi.signal.test")]
+    #[error("event_type must match the lowercase namespaced MUEF form, e.g. migi.signal.test")]
     InvalidEventType,
-    #[error("event payload must be an object")]
-    InvalidPayload,
 }
 
 pub fn validate_event(event: &MuefEvent) -> Result<(), CoreError> {
     if event.schema_version != "muef.v0" {
         return Err(CoreError::InvalidSchemaVersion);
     }
+
+    let valid_segment = |segment: &str| {
+        let mut chars = segment.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    };
+
     let parts: Vec<&str> = event.event_type.split('.').collect();
-    if parts.len() < 2 || parts.iter().any(|p| p.is_empty() || !p.chars().next().unwrap().is_ascii_lowercase()) {
+    if parts.len() < 2 || parts.iter().any(|part| !valid_segment(part)) {
         return Err(CoreError::InvalidEventType);
     }
     Ok(())
@@ -135,6 +141,10 @@ pub fn issue_receipt(
     validate_event(event)?;
     let input_hash = sha256_json(event);
     let output_hash = sha256_json(output);
+    let mut metadata = serde_json::Map::new();
+    metadata.insert("input_hash".into(), serde_json::Value::String(input_hash));
+    metadata.insert("output_hash".into(), serde_json::Value::String(output_hash.clone()));
+
     Ok(MigiReceipt {
         schema_version: "migi-receipt.v0".into(),
         receipt_id: Uuid::new_v4().to_string(),
@@ -142,11 +152,10 @@ pub fn issue_receipt(
         event_id: event.event_id.clone(),
         source_class: SourceClass::Executed,
         intent_ref: event.event_id.clone(),
-        output_ref: output_hash.clone(),
+        output_ref: output_hash,
         previous_receipt_ref: previous_receipt_ref.into(),
         authority,
-        input_hash,
-        output_hash,
+        metadata,
     })
 }
 
@@ -165,14 +174,20 @@ mod tests {
     }
 
     #[test]
+    fn source_class_serializes_like_the_json_schema() {
+        assert_eq!(serde_json::to_string(&SourceClass::Original).unwrap(), "\"original\"");
+        assert_eq!(serde_json::to_string(&SourceClass::Executed).unwrap(), "\"executed\"");
+    }
+
+    #[test]
     fn receipt_chains_event_and_hashes_output() {
         let event = MuefEvent::new("migi.signal.test", actor(), SourceClass::Original);
         let authority = Authority { tre_logic: TreLogic::Proceed, reason_code: "test_allowed".into(), consent_scope: None };
         let output = serde_json::json!({"message": "hello"});
         let receipt = issue_receipt(&event, authority, &output, "genesis").unwrap();
         assert_eq!(receipt.event_id, event.event_id);
-        assert!(receipt.input_hash.starts_with("sha256:"));
-        assert!(receipt.output_hash.starts_with("sha256:"));
+        assert!(receipt.output_ref.starts_with("sha256:"));
+        assert!(receipt.metadata["input_hash"].as_str().unwrap().starts_with("sha256:"));
         assert_eq!(receipt.previous_receipt_ref, "genesis");
     }
 

--- a/crates/migi-core/src/lib.rs
+++ b/crates/migi-core/src/lib.rs
@@ -1,0 +1,185 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ActorType {
+    User,
+    Agent,
+    Service,
+    Device,
+    Organization,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Actor {
+    #[serde(rename = "type")]
+    pub actor_type: ActorType,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SourceClass {
+    Original,
+    Observed,
+    Derived,
+    Simulated,
+    Proposed,
+    Authorized,
+    Executed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TreLogic {
+    #[serde(rename = "+1")]
+    Proceed,
+    #[serde(rename = "0")]
+    Hold,
+    #[serde(rename = "-1")]
+    Deny,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Authority {
+    pub tre_logic: TreLogic,
+    pub reason_code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consent_scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MuefEvent {
+    pub schema_version: String,
+    pub event_id: String,
+    pub event_type: String,
+    pub occurred_at: DateTime<Utc>,
+    pub actor: Actor,
+    pub source_class: SourceClass,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<Authority>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_id: Option<String>,
+    pub payload: serde_json::Map<String, serde_json::Value>,
+}
+
+impl MuefEvent {
+    pub fn new(event_type: impl Into<String>, actor: Actor, source_class: SourceClass) -> Self {
+        Self {
+            schema_version: "muef.v0".into(),
+            event_id: Uuid::new_v4().to_string(),
+            event_type: event_type.into(),
+            occurred_at: Utc::now(),
+            actor,
+            source_class,
+            authority: None,
+            parent_event_id: None,
+            receipt_id: None,
+            payload: serde_json::Map::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigiReceipt {
+    pub schema_version: String,
+    pub receipt_id: String,
+    pub issued_at: DateTime<Utc>,
+    pub event_id: String,
+    pub source_class: SourceClass,
+    pub intent_ref: String,
+    pub output_ref: String,
+    pub previous_receipt_ref: String,
+    pub authority: Authority,
+    pub input_hash: String,
+    pub output_hash: String,
+}
+
+#[derive(Debug, Error)]
+pub enum CoreError {
+    #[error("event schema_version must be muef.v0")]
+    InvalidSchemaVersion,
+    #[error("event_type must be namespaced, e.g. migi.signal.test")]
+    InvalidEventType,
+    #[error("event payload must be an object")]
+    InvalidPayload,
+}
+
+pub fn validate_event(event: &MuefEvent) -> Result<(), CoreError> {
+    if event.schema_version != "muef.v0" {
+        return Err(CoreError::InvalidSchemaVersion);
+    }
+    let parts: Vec<&str> = event.event_type.split('.').collect();
+    if parts.len() < 2 || parts.iter().any(|p| p.is_empty() || !p.chars().next().unwrap().is_ascii_lowercase()) {
+        return Err(CoreError::InvalidEventType);
+    }
+    Ok(())
+}
+
+pub fn sha256_json<T: Serialize>(value: &T) -> String {
+    let bytes = serde_json::to_vec(value).expect("serializable value");
+    let digest = Sha256::digest(bytes);
+    format!("sha256:{digest:x}")
+}
+
+pub fn issue_receipt(
+    event: &MuefEvent,
+    authority: Authority,
+    output: &serde_json::Value,
+    previous_receipt_ref: impl Into<String>,
+) -> Result<MigiReceipt, CoreError> {
+    validate_event(event)?;
+    let input_hash = sha256_json(event);
+    let output_hash = sha256_json(output);
+    Ok(MigiReceipt {
+        schema_version: "migi-receipt.v0".into(),
+        receipt_id: Uuid::new_v4().to_string(),
+        issued_at: Utc::now(),
+        event_id: event.event_id.clone(),
+        source_class: SourceClass::Executed,
+        intent_ref: event.event_id.clone(),
+        output_ref: output_hash.clone(),
+        previous_receipt_ref: previous_receipt_ref.into(),
+        authority,
+        input_hash,
+        output_hash,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor() -> Actor {
+        Actor { actor_type: ActorType::Service, id: "migi-test-node".into() }
+    }
+
+    #[test]
+    fn muef_event_validates() {
+        let event = MuefEvent::new("migi.signal.test", actor(), SourceClass::Original);
+        assert!(validate_event(&event).is_ok());
+    }
+
+    #[test]
+    fn receipt_chains_event_and_hashes_output() {
+        let event = MuefEvent::new("migi.signal.test", actor(), SourceClass::Original);
+        let authority = Authority { tre_logic: TreLogic::Proceed, reason_code: "test_allowed".into(), consent_scope: None };
+        let output = serde_json::json!({"message": "hello"});
+        let receipt = issue_receipt(&event, authority, &output, "genesis").unwrap();
+        assert_eq!(receipt.event_id, event.event_id);
+        assert!(receipt.input_hash.starts_with("sha256:"));
+        assert!(receipt.output_hash.starts_with("sha256:"));
+        assert_eq!(receipt.previous_receipt_ref, "genesis");
+    }
+
+    #[test]
+    fn tre_logic_serializes_to_protocol_values() {
+        assert_eq!(serde_json::to_string(&TreLogic::Proceed).unwrap(), "\"+1\"");
+        assert_eq!(serde_json::to_string(&TreLogic::Hold).unwrap(), "\"0\"");
+        assert_eq!(serde_json::to_string(&TreLogic::Deny).unwrap(), "\"-1\"");
+    }
+}

--- a/crates/migi-core/tests/migi_cs_001.rs
+++ b/crates/migi-core/tests/migi_cs_001.rs
@@ -18,6 +18,7 @@ fn verifiable_signal_loop() {
 
     assert_eq!(receipt.event_id, event.event_id);
     assert_eq!(receipt.previous_receipt_ref, "genesis");
-    assert!(receipt.input_hash.starts_with("sha256:"));
-    assert!(receipt.output_hash.starts_with("sha256:"));
+    assert!(receipt.output_ref.starts_with("sha256:"));
+    assert!(receipt.metadata["input_hash"].as_str().unwrap().starts_with("sha256:"));
+    assert!(receipt.metadata["output_hash"].as_str().unwrap().starts_with("sha256:"));
 }

--- a/crates/migi-core/tests/migi_cs_001.rs
+++ b/crates/migi-core/tests/migi_cs_001.rs
@@ -1,0 +1,23 @@
+use migi_core::{issue_receipt, validate_event, Actor, ActorType, Authority, MuefEvent, SourceClass, TreLogic};
+
+#[test]
+fn verifiable_signal_loop() {
+    let actor = Actor { actor_type: ActorType::Service, id: "node-b".into() };
+    let mut event = MuefEvent::new("migi.signal.test", actor, SourceClass::Original);
+    event.payload.insert("message".into(), serde_json::json!("hello"));
+
+    assert!(validate_event(&event).is_ok());
+
+    let authority = Authority {
+        tre_logic: TreLogic::Proceed,
+        reason_code: "test_allowed".into(),
+        consent_scope: Some("local-test".into()),
+    };
+    let output = serde_json::json!({ "message": "hello", "node": "node-b" });
+    let receipt = issue_receipt(&event, authority, &output, "genesis").expect("receipt");
+
+    assert_eq!(receipt.event_id, event.event_id);
+    assert_eq!(receipt.previous_receipt_ref, "genesis");
+    assert!(receipt.input_hash.starts_with("sha256:"));
+    assert!(receipt.output_hash.starts_with("sha256:"));
+}

--- a/crates/migi-recall/Cargo.toml
+++ b/crates/migi-recall/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "migi-recall"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/migi-recall/src/bin/migi-recall.rs
+++ b/crates/migi-recall/src/bin/migi-recall.rs
@@ -1,0 +1,117 @@
+use migi_recall::import::{extract_fenced_code, ImportContext};
+use migi_recall::{ArtifactStatus, CodeSource, RecallIndex, RecallQuery, SourceKind};
+use std::env;
+use std::error::Error;
+use std::fs;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("migi-recall error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("import") => import_command(&args[2..]),
+        Some("search") => search_command(&args[2..]),
+        Some("verify") => verify_command(&args[2..]),
+        _ => {
+            print_usage();
+            Ok(())
+        }
+    }
+}
+
+fn import_command(args: &[String]) -> Result<(), Box<dyn Error>> {
+    if args.len() < 4 {
+        return Err("usage: migi-recall import <input.md> <output.jsonl> <source-kind> <source-uri> [status]".into());
+    }
+
+    let input_path = &args[0];
+    let output_path = &args[1];
+    let source_kind = parse_source_kind(&args[2])?;
+    let source_uri = args[3].clone();
+    let status = args
+        .get(4)
+        .map(|value| parse_status(value))
+        .transpose()?
+        .unwrap_or(ArtifactStatus::Prototype);
+
+    let text = fs::read_to_string(input_path)?;
+    let source = CodeSource {
+        kind: source_kind,
+        uri: source_uri,
+        path: Some(input_path.clone()),
+        revision: None,
+        conversation_id: None,
+        message_id: None,
+    };
+    let context = ImportContext::new(source, status);
+    let artifacts = extract_fenced_code(&text, &context);
+
+    let mut index = RecallIndex::new();
+    for artifact in artifacts {
+        index.ingest(artifact)?;
+    }
+    index.save_jsonl(output_path)?;
+    println!("indexed {} code artifacts into {}", index.len(), output_path);
+    Ok(())
+}
+
+fn search_command(args: &[String]) -> Result<(), Box<dyn Error>> {
+    if args.len() < 2 {
+        return Err("usage: migi-recall search <index.jsonl> <query...>".into());
+    }
+    let index = RecallIndex::load_jsonl(&args[0])?;
+    let query_text = args[1..].join(" ");
+    let hits = index.search(&RecallQuery::text(query_text));
+    println!("{}", serde_json::to_string_pretty(&hits)?);
+    Ok(())
+}
+
+fn verify_command(args: &[String]) -> Result<(), Box<dyn Error>> {
+    if args.len() != 1 {
+        return Err("usage: migi-recall verify <index.jsonl>".into());
+    }
+    let index = RecallIndex::load_jsonl(&args[0])?;
+    println!("verified {} code artifacts", index.len());
+    Ok(())
+}
+
+fn parse_source_kind(value: &str) -> Result<SourceKind, Box<dyn Error>> {
+    match value.to_ascii_lowercase().as_str() {
+        "chat" => Ok(SourceKind::Chat),
+        "log" => Ok(SourceKind::Log),
+        "repository" | "repo" => Ok(SourceKind::Repository),
+        "file" => Ok(SourceKind::File),
+        "generated" => Ok(SourceKind::Generated),
+        "external" => Ok(SourceKind::External),
+        other => Err(format!("unknown source kind: {other}").into()),
+    }
+}
+
+fn parse_status(value: &str) -> Result<ArtifactStatus, Box<dyn Error>> {
+    match value.to_ascii_lowercase().as_str() {
+        "concept" => Ok(ArtifactStatus::Concept),
+        "specification" | "spec" => Ok(ArtifactStatus::Specification),
+        "prototype" => Ok(ArtifactStatus::Prototype),
+        "executable" => Ok(ArtifactStatus::Executable),
+        "tested" => Ok(ArtifactStatus::Tested),
+        "deprecated" => Ok(ArtifactStatus::Deprecated),
+        other => Err(format!("unknown artifact status: {other}").into()),
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "MIGI RAG0SHOT code recall\n\n\
+         Commands:\n\
+           migi-recall import <input.md> <output.jsonl> <source-kind> <source-uri> [status]\n\
+           migi-recall search <index.jsonl> <query...>\n\
+           migi-recall verify <index.jsonl>\n\n\
+         source-kind: chat | log | repository | file | generated | external\n\
+         status: concept | specification | prototype | executable | tested | deprecated"
+    );
+}

--- a/crates/migi-recall/src/import.rs
+++ b/crates/migi-recall/src/import.rs
@@ -1,0 +1,159 @@
+use crate::{ArtifactStatus, CodeArtifact, CodeSource};
+
+#[derive(Debug, Clone)]
+pub struct ImportContext {
+    pub source: CodeSource,
+    pub status: ArtifactStatus,
+    pub named_systems: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+impl ImportContext {
+    pub fn new(source: CodeSource, status: ArtifactStatus) -> Self {
+        Self {
+            source,
+            status,
+            named_systems: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+}
+
+/// Extract Markdown-style fenced code blocks from chat exports, notes, logs,
+/// or documentation without altering the code inside each fence.
+///
+/// The importer deliberately does not execute or "fix" recovered code. It
+/// creates provenance-carrying CodeArtifact records that can be recalled,
+/// compared, reviewed, and later routed to an approved runtime adapter.
+pub fn extract_fenced_code(text: &str, context: &ImportContext) -> Vec<CodeArtifact> {
+    let mut artifacts = Vec::new();
+    let mut in_fence = false;
+    let mut language = String::new();
+    let mut buffer = String::new();
+    let mut block_number = 0usize;
+
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if !in_fence {
+            if let Some(rest) = trimmed.strip_prefix("```") {
+                in_fence = true;
+                language = canonical_language(rest.trim().split_whitespace().next().unwrap_or("text"));
+                if language.is_empty() {
+                    language = "text".into();
+                }
+                buffer.clear();
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("```") {
+            block_number += 1;
+            let mut artifact = CodeArtifact::new(
+                format!("Recovered {} block {}", language, block_number),
+                language.clone(),
+                format_for_language(&language),
+                buffer.trim_end_matches('\n').to_string(),
+                context.source.clone(),
+                context.status.clone(),
+            );
+            artifact.named_systems = context.named_systems.clone();
+            artifact.tags = context.tags.clone();
+            artifacts.push(artifact);
+            in_fence = false;
+            language.clear();
+            buffer.clear();
+            continue;
+        }
+
+        buffer.push_str(line);
+        buffer.push('\n');
+    }
+
+    artifacts
+}
+
+pub fn canonical_language(language: &str) -> String {
+    let normalized = language.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "rs" => "rust".into(),
+        "py" => "python".into(),
+        "c++" | "cc" | "cxx" => "cpp".into(),
+        "kt" | "kts" => "kotlin".into(),
+        "ts" | "tsx" => "typescript".into(),
+        "js" | "jsx" | "web3.js" => "javascript".into(),
+        "c#" | "cs" => "csharp".into(),
+        "sol" => "solidity".into(),
+        "sh" | "bash" | "zsh" => "shell".into(),
+        "yml" => "yaml".into(),
+        "md" => "markdown".into(),
+        "jsonschema" | "json_schema" => "json-schema".into(),
+        "emoji" | "emoji-a-plus-plus" | "emoji-a++" => "emoji-a++".into(),
+        "tre" | "trelogic" | "tre_logic" | "tre-logic" => "tre-logic".into(),
+        "" => "text".into(),
+        other => other.replace(' ', "-"),
+    }
+}
+
+pub fn format_for_language(language: &str) -> &'static str {
+    match language {
+        "json-schema" => "schema",
+        "json" => "data",
+        "yaml" | "toml" => "config",
+        "sql" => "query",
+        "markdown" => "documentation",
+        "emoji-a++" | "tre-logic" => "workflow",
+        _ => "source",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SourceKind};
+
+    fn context() -> ImportContext {
+        ImportContext::new(
+            CodeSource {
+                kind: SourceKind::Chat,
+                uri: "chat:example".into(),
+                path: None,
+                revision: None,
+                conversation_id: Some("conversation-1".into()),
+                message_id: Some("message-7".into()),
+            },
+            ArtifactStatus::Prototype,
+        )
+    }
+
+    #[test]
+    fn extracts_multiple_languages_without_rewriting_code() {
+        let text = r#"
+Discussion before code.
+
+```python
+def recall(query):
+    return query
+```
+
+```c++
+void on_can_frame() {}
+```
+"#;
+
+        let artifacts = extract_fenced_code(text, &context());
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts[0].language, "python");
+        assert_eq!(artifacts[0].content, "def recall(query):\n    return query");
+        assert_eq!(artifacts[1].language, "cpp");
+        assert_eq!(artifacts[1].content, "void on_can_frame() {}");
+        assert!(artifacts.iter().all(|artifact| artifact.verify_hash()));
+    }
+
+    #[test]
+    fn maps_symbolic_and_schema_formats() {
+        assert_eq!(canonical_language("emoji-a++"), "emoji-a++");
+        assert_eq!(format_for_language("emoji-a++"), "workflow");
+        assert_eq!(canonical_language("jsonschema"), "json-schema");
+        assert_eq!(format_for_language("json-schema"), "schema");
+    }
+}

--- a/crates/migi-recall/src/lib.rs
+++ b/crates/migi-recall/src/lib.rs
@@ -85,12 +85,14 @@ impl CodeArtifact {
         status: ArtifactStatus,
     ) -> Self {
         let content = content.into();
+        let language = language.into();
+        let format = format.into();
         Self {
             schema_version: CODE_ARTIFACT_SCHEMA.into(),
             artifact_id: Uuid::new_v4().to_string(),
             title: title.into(),
-            language: normalize_id(&language.into()),
-            format: normalize_id(&format.into()),
+            language: normalize_id(&language),
+            format: normalize_id(&format),
             content_hash: sha256_text(&content),
             content,
             source,
@@ -186,7 +188,7 @@ impl RecallIndex {
                     && (query.source_kinds.is_empty() || query.source_kinds.contains(&artifact.source.kind))
                     && (system_filters.is_empty()
                         || system_filters.iter().any(|wanted| {
-                            artifact.named_systems.iter().any(|s| s.to_ascii_lowercase() == *wanted)
+                            artifact.named_systems.iter().any(|s| s.eq_ignore_ascii_case(wanted))
                         }))
             })
             .filter_map(|artifact| {
@@ -245,6 +247,8 @@ impl RecallIndex {
 pub enum RecallError {
     #[error("unsupported code artifact schema: {0}")]
     UnsupportedSchema(String),
+    #[error("required artifact field is empty: {0}")]
+    EmptyField(&'static str),
     #[error("artifact content hash does not match content for {0}")]
     HashMismatch(String),
     #[error("I/O error: {0}")]
@@ -258,6 +262,17 @@ pub enum RecallError {
 pub fn validate_artifact(artifact: &CodeArtifact) -> Result<(), RecallError> {
     if artifact.schema_version != CODE_ARTIFACT_SCHEMA {
         return Err(RecallError::UnsupportedSchema(artifact.schema_version.clone()));
+    }
+    for (name, value) in [
+        ("artifact_id", artifact.artifact_id.as_str()),
+        ("title", artifact.title.as_str()),
+        ("language", artifact.language.as_str()),
+        ("format", artifact.format.as_str()),
+        ("source.uri", artifact.source.uri.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(RecallError::EmptyField(name));
+        }
     }
     if !artifact.verify_hash() {
         return Err(RecallError::HashMismatch(artifact.artifact_id.clone()));

--- a/crates/migi-recall/src/lib.rs
+++ b/crates/migi-recall/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod import;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/migi-recall/src/lib.rs
+++ b/crates/migi-recall/src/lib.rs
@@ -1,0 +1,425 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::Path;
+use thiserror::Error;
+use uuid::Uuid;
+
+pub const CODE_ARTIFACT_SCHEMA: &str = "migi-code-artifact.v0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Chat,
+    Log,
+    Repository,
+    File,
+    Generated,
+    External,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactStatus {
+    Concept,
+    Specification,
+    Prototype,
+    Executable,
+    Tested,
+    Deprecated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodeSource {
+    pub kind: SourceKind,
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodeArtifact {
+    pub schema_version: String,
+    pub artifact_id: String,
+    pub title: String,
+    /// Open identifier such as rust, python, cpp, kotlin, typescript, solidity,
+    /// sql, cobol, json-schema, yaml, emoji-a++, or tre-logic.
+    pub language: String,
+    /// source, schema, config, query, workflow, documentation, or another
+    /// caller-defined format.
+    pub format: String,
+    pub content: String,
+    pub source: CodeSource,
+    pub status: ArtifactStatus,
+    #[serde(default)]
+    pub named_systems: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub symbols: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_adapter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub content_hash: String,
+}
+
+impl CodeArtifact {
+    pub fn new(
+        title: impl Into<String>,
+        language: impl Into<String>,
+        format: impl Into<String>,
+        content: impl Into<String>,
+        source: CodeSource,
+        status: ArtifactStatus,
+    ) -> Self {
+        let content = content.into();
+        Self {
+            schema_version: CODE_ARTIFACT_SCHEMA.into(),
+            artifact_id: Uuid::new_v4().to_string(),
+            title: title.into(),
+            language: normalize_id(&language.into()),
+            format: normalize_id(&format.into()),
+            content_hash: sha256_text(&content),
+            content,
+            source,
+            status,
+            named_systems: Vec::new(),
+            tags: Vec::new(),
+            symbols: Vec::new(),
+            runtime_adapter: None,
+            parent_artifact_id: None,
+            receipt_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    pub fn verify_hash(&self) -> bool {
+        self.content_hash == sha256_text(&self.content)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RecallQuery {
+    pub text: String,
+    pub languages: Vec<String>,
+    pub named_systems: Vec<String>,
+    pub source_kinds: Vec<SourceKind>,
+    pub limit: usize,
+}
+
+impl RecallQuery {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            limit: 8,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecallHit {
+    pub score: u32,
+    pub artifact_id: String,
+    pub title: String,
+    pub language: String,
+    pub format: String,
+    pub source: CodeSource,
+    pub content_hash: String,
+    pub receipt_id: Option<String>,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RecallIndex {
+    artifacts: Vec<CodeArtifact>,
+}
+
+impl RecallIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.artifacts.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+
+    pub fn artifacts(&self) -> &[CodeArtifact] {
+        &self.artifacts
+    }
+
+    pub fn ingest(&mut self, artifact: CodeArtifact) -> Result<(), RecallError> {
+        validate_artifact(&artifact)?;
+        self.artifacts.push(artifact);
+        Ok(())
+    }
+
+    /// Baseline RAG0SHOT recall: deterministic lexical + metadata retrieval.
+    /// A vector/embedding retriever can be added later without changing the
+    /// artifact/provenance contract.
+    pub fn search(&self, query: &RecallQuery) -> Vec<RecallHit> {
+        let query_tokens = tokenize(&query.text);
+        let language_filters: Vec<String> = query.languages.iter().map(|v| normalize_id(v)).collect();
+        let system_filters: Vec<String> = query.named_systems.iter().map(|v| v.to_ascii_lowercase()).collect();
+
+        let mut hits: Vec<RecallHit> = self
+            .artifacts
+            .iter()
+            .filter(|artifact| {
+                (language_filters.is_empty() || language_filters.contains(&normalize_id(&artifact.language)))
+                    && (query.source_kinds.is_empty() || query.source_kinds.contains(&artifact.source.kind))
+                    && (system_filters.is_empty()
+                        || system_filters.iter().any(|wanted| {
+                            artifact.named_systems.iter().any(|s| s.to_ascii_lowercase() == *wanted)
+                        }))
+            })
+            .filter_map(|artifact| {
+                let score = score_artifact(artifact, &query_tokens);
+                if score == 0 && !query_tokens.is_empty() {
+                    return None;
+                }
+                Some(RecallHit {
+                    score,
+                    artifact_id: artifact.artifact_id.clone(),
+                    title: artifact.title.clone(),
+                    language: artifact.language.clone(),
+                    format: artifact.format.clone(),
+                    source: artifact.source.clone(),
+                    content_hash: artifact.content_hash.clone(),
+                    receipt_id: artifact.receipt_id.clone(),
+                    snippet: select_snippet(&artifact.content, &query_tokens),
+                })
+            })
+            .collect();
+
+        hits.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.artifact_id.cmp(&b.artifact_id)));
+        hits.truncate(if query.limit == 0 { 8 } else { query.limit });
+        hits
+    }
+
+    pub fn save_jsonl(&self, path: impl AsRef<Path>) -> Result<(), RecallError> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        for artifact in &self.artifacts {
+            serde_json::to_writer(&mut writer, artifact)?;
+            writer.write_all(b"\n")?;
+        }
+        writer.flush()?;
+        Ok(())
+    }
+
+    pub fn load_jsonl(path: impl AsRef<Path>) -> Result<Self, RecallError> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut index = Self::new();
+        for (line_number, line) in reader.lines().enumerate() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let artifact: CodeArtifact = serde_json::from_str(&line)
+                .map_err(|source| RecallError::JsonLine { line: line_number + 1, source })?;
+            index.ingest(artifact)?;
+        }
+        Ok(index)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RecallError {
+    #[error("unsupported code artifact schema: {0}")]
+    UnsupportedSchema(String),
+    #[error("artifact content hash does not match content for {0}")]
+    HashMismatch(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("JSON error on line {line}: {source}")]
+    JsonLine { line: usize, source: serde_json::Error },
+}
+
+pub fn validate_artifact(artifact: &CodeArtifact) -> Result<(), RecallError> {
+    if artifact.schema_version != CODE_ARTIFACT_SCHEMA {
+        return Err(RecallError::UnsupportedSchema(artifact.schema_version.clone()));
+    }
+    if !artifact.verify_hash() {
+        return Err(RecallError::HashMismatch(artifact.artifact_id.clone()));
+    }
+    Ok(())
+}
+
+pub fn sha256_text(content: &str) -> String {
+    let digest = Sha256::digest(content.as_bytes());
+    format!("sha256:{digest:x}")
+}
+
+fn normalize_id(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace(' ', "-")
+}
+
+fn tokenize(value: &str) -> Vec<String> {
+    value
+        .split(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '+' | '#' | '-')))
+        .filter(|token| token.len() > 1)
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
+}
+
+fn score_artifact(artifact: &CodeArtifact, query_tokens: &[String]) -> u32 {
+    if query_tokens.is_empty() {
+        return 1;
+    }
+
+    let content = artifact.content.to_ascii_lowercase();
+    let title = artifact.title.to_ascii_lowercase();
+    let language = artifact.language.to_ascii_lowercase();
+    let format = artifact.format.to_ascii_lowercase();
+    let tags = artifact.tags.join(" ").to_ascii_lowercase();
+    let systems = artifact.named_systems.join(" ").to_ascii_lowercase();
+    let symbols = artifact.symbols.join(" ").to_ascii_lowercase();
+
+    query_tokens.iter().fold(0u32, |score, token| {
+        score
+            + if content.contains(token) { 3 } else { 0 }
+            + if title.contains(token) { 6 } else { 0 }
+            + if language.contains(token) || format.contains(token) { 4 } else { 0 }
+            + if tags.contains(token) { 5 } else { 0 }
+            + if systems.contains(token) { 7 } else { 0 }
+            + if symbols.contains(token) { 8 } else { 0 }
+    })
+}
+
+fn select_snippet(content: &str, query_tokens: &[String]) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    let match_index = lines.iter().position(|line| {
+        let lower = line.to_ascii_lowercase();
+        query_tokens.iter().any(|token| lower.contains(token))
+    });
+
+    let index = match_index.unwrap_or(0);
+    let start = index.saturating_sub(1);
+    let end = (index + 2).min(lines.len());
+    lines[start..end].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(kind: SourceKind, uri: &str) -> CodeSource {
+        CodeSource {
+            kind,
+            uri: uri.into(),
+            path: None,
+            revision: None,
+            conversation_id: None,
+            message_id: None,
+        }
+    }
+
+    #[test]
+    fn recalls_across_code_formats_with_provenance() {
+        let mut index = RecallIndex::new();
+
+        let mut rust = CodeArtifact::new(
+            "MIGIReceipt issuer",
+            "rust",
+            "source",
+            "pub fn issue_receipt() { /* provenance */ }",
+            source(SourceKind::Repository, "github:QSTARMIGI/MIGI"),
+            ArtifactStatus::Tested,
+        );
+        rust.named_systems.push("MIGIReceipt".into());
+        rust.symbols.push("issue_receipt".into());
+        index.ingest(rust).unwrap();
+
+        let mut emoji = CodeArtifact::new(
+            "Emoji A++ receipt workflow",
+            "emoji-a++",
+            "workflow",
+            "📷 capture → 🧾 receipt → 🧠 analyze",
+            source(SourceKind::Chat, "chat:migi-emoji-workflow"),
+            ArtifactStatus::Specification,
+        );
+        emoji.named_systems.push("Emoji A++".into());
+        emoji.tags.push("receipt".into());
+        index.ingest(emoji).unwrap();
+
+        let hits = index.search(&RecallQuery::text("receipt provenance"));
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|hit| hit.content_hash.starts_with("sha256:")));
+        assert!(hits.iter().any(|hit| hit.source.kind == SourceKind::Chat));
+        assert!(hits.iter().any(|hit| hit.source.kind == SourceKind::Repository));
+    }
+
+    #[test]
+    fn can_filter_by_language_and_named_system() {
+        let mut index = RecallIndex::new();
+        let mut python = CodeArtifact::new(
+            "RAG0SHOT Python prototype",
+            "python",
+            "source",
+            "def recall(query): return query",
+            source(SourceKind::Log, "log:rag0shot"),
+            ArtifactStatus::Prototype,
+        );
+        python.named_systems.push("RAG0SHOT".into());
+        index.ingest(python).unwrap();
+
+        let query = RecallQuery {
+            text: "recall".into(),
+            languages: vec!["python".into()],
+            named_systems: vec!["RAG0SHOT".into()],
+            source_kinds: vec![SourceKind::Log],
+            limit: 4,
+        };
+        let hits = index.search(&query);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].language, "python");
+    }
+
+    #[test]
+    fn jsonl_round_trip_preserves_hash_and_source() {
+        let mut index = RecallIndex::new();
+        index
+            .ingest(CodeArtifact::new(
+                "CAN adapter sketch",
+                "cpp",
+                "source",
+                "void on_can_frame() {}",
+                source(SourceKind::File, "file:can-adapter.cpp"),
+                ArtifactStatus::Prototype,
+            ))
+            .unwrap();
+
+        let path = std::env::temp_dir().join(format!("migi-recall-{}.jsonl", Uuid::new_v4()));
+        index.save_jsonl(&path).unwrap();
+        let loaded = RecallIndex::load_jsonl(&path).unwrap();
+        std::fs::remove_file(path).ok();
+
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded.artifacts()[0].verify_hash());
+        assert_eq!(loaded.artifacts()[0].source.kind, SourceKind::File);
+    }
+}

--- a/docs/architecture/rag0shot-code-recall.md
+++ b/docs/architecture/rag0shot-code-recall.md
@@ -1,0 +1,210 @@
+# RAG0SHOT Code Recall
+
+> Status: experimental baseline
+
+RAG0SHOT code recall gives MIGI one provenance-preserving memory format for code recovered from chats, logs, repository history, files, experiments, and generated work.
+
+It is intentionally **polyglot for recall and adapter-gated for execution**.
+
+## Core rule
+
+```text
+Recall != execution
+```
+
+MIGI may remember, compare, rank, cite, and explain any indexed code artifact. Running that artifact requires a separately approved runtime adapter, an authority decision, and an execution receipt.
+
+## Historical format families
+
+The current registry covers the recurring formats recovered from MIGI/Mogo-Lab work:
+
+```text
+Systems / low level:
+  Rust, C, C++, Shell
+
+Mobile / JVM:
+  Kotlin, Java, Android NDK/JNI, Vulkan
+
+AI / scientific / simulation:
+  Python, Haskell, Fortran, Qiskit-tagged Python
+
+Web / XR:
+  TypeScript, JavaScript, HTML, CSS, React, Vite, Astro,
+  Three.js, WebXR
+
+Enterprise / data:
+  SQL, COBOL, Ruby/Rails
+
+Web3:
+  Solidity, Web3.js-tagged JavaScript
+
+Schemas / configuration / documentation:
+  JSON, JSON Schema, YAML, TOML, Markdown
+
+MIGI symbolic formats:
+  Emoji A++, Emoji ASCII++, Tre Logic
+
+Research/reference:
+  Plank and future caller-defined language identifiers
+```
+
+The registry is open-ended. Unknown languages can still be indexed because `language` and `format` are string identifiers rather than a closed enum.
+
+## Artifact pipeline
+
+```text
+Chat / Log / Repo / File / Generated Output
+                 |
+                 v
+          snippet extraction
+                 |
+                 v
+        MIGI Code Artifact v0
+        - language
+        - format
+        - original content
+        - source URI
+        - path/revision/message refs
+        - status
+        - named system tags
+        - symbols
+        - runtime adapter (optional)
+        - parent artifact
+        - receipt
+        - SHA-256 content hash
+                 |
+                 v
+          RAG0SHOT index
+                 |
+        +--------+---------+
+        |                  |
+        v                  v
+ exact/lexical       future vector/
+ metadata recall     semantic recall
+        |                  |
+        +--------+---------+
+                 v
+          provenance rerank
+                 |
+                 v
+        recalled code + source
+                 |
+                 v
+        authority / Tre Logic
+                 |
+      optional runtime adapter
+                 |
+                 v
+          execution receipt
+```
+
+## Recall tiers
+
+### Tier 0 — identity recall
+
+Look up exact artifact IDs, content hashes, receipt IDs, source paths, symbols, or known system names.
+
+### Tier 1 — RAG0SHOT baseline
+
+`migi-recall` currently performs deterministic lexical + metadata ranking across title, language, format, tags, named systems, symbols, and code content.
+
+This is intentionally useful without an embedding model or network connection.
+
+### Tier 2 — semantic retrieval
+
+A future embedding/vector adapter may rank artifacts semantically. It must return the same `RecallHit` provenance envelope and must never replace the original source/hash.
+
+### Tier 3 — graph / lineage recall
+
+ChainLog, receipt parentage, code parentage, project relationships, and future graph storage can expand a hit into its lineage:
+
+```text
+original snippet
+ -> revision
+ -> transpiled form
+ -> executable form
+ -> test result
+ -> receipt
+```
+
+## Execution adapters
+
+A `runtime_adapter` is a capability reference, not permission to run code.
+
+Examples:
+
+```text
+rust        -> rust-cargo
+python      -> python
+cpp         -> native-cpp
+kotlin      -> android-gradle
+typescript  -> node
+javascript  -> node-or-browser
+csharp      -> dotnet-or-unity
+solidity    -> evm-toolchain
+sql         -> database
+emoji-a++   -> alchemy-compiler
+tre-logic   -> tre-rule-engine
+```
+
+Before execution:
+
+```text
+Recall hit
+ -> verify content hash
+ -> resolve exact artifact/revision
+ -> LUFITGuard / Tre Logic
+ -> select runtime adapter
+ -> execute in scoped environment
+ -> record output
+ -> issue MIGIReceipt
+ -> append lineage
+```
+
+## Historical chat/log import contract
+
+An importer should preserve the original code block exactly and wrap it in `migi-code-artifact.v0`.
+
+For a chat-derived snippet, record when available:
+
+```text
+source.kind = chat
+source.uri = stable conversation/export reference
+source.conversation_id
+source.message_id
+language
+format
+named_systems
+tags
+status
+```
+
+For repository code, also record:
+
+```text
+source.kind = repository
+source.uri = repository identifier
+source.path
+source.revision = commit SHA / tag / branch snapshot
+```
+
+For run logs or generated artifacts, use `log` or `generated` and link `parent_artifact_id` / `receipt_id` whenever known.
+
+## Storage
+
+The first implementation supports newline-delimited JSON (`JSONL`) so artifacts are inspectable, diffable, and portable.
+
+Later stores may include SQLite/ChainLog for local persistence and graph/vector projections for advanced retrieval. Those projections must never become the sole copy of provenance.
+
+## Safety and provenance invariants
+
+1. Preserve original code content.
+2. Hash every artifact.
+3. Require a source reference.
+4. Distinguish concept/specification/prototype/executable/tested/deprecated.
+5. Recall does not imply correctness.
+6. Recall does not imply authorization.
+7. Transpilation creates a child artifact; it never overwrites the original.
+8. Execution requires an approved adapter and authority path.
+9. Executions produce receipts and lineage.
+10. Semantic/vector indexes are projections; source artifacts remain canonical.

--- a/provenance/code-formats.yaml
+++ b/provenance/code-formats.yaml
@@ -1,0 +1,177 @@
+registry_version: 1
+purpose: >
+  Canonical vocabulary for indexing historical MIGI/Mogo-Lab code through RAG0SHOT.
+  Recall is allowed for every listed format. Execution is separate and requires an
+  approved runtime adapter, authority decision, and receipt.
+
+languages:
+  - id: rust
+    kind: source
+    recall: true
+    execution_adapter: rust-cargo
+    execution_status: prototype
+  - id: python
+    kind: source
+    recall: true
+    execution_adapter: python
+    execution_status: prototype
+  - id: c
+    kind: source
+    recall: true
+    execution_adapter: native-c
+    execution_status: planned
+  - id: cpp
+    aliases: [c++]
+    kind: source
+    recall: true
+    execution_adapter: native-cpp
+    execution_status: planned
+  - id: kotlin
+    kind: source
+    recall: true
+    execution_adapter: android-gradle
+    execution_status: planned
+  - id: java
+    kind: source
+    recall: true
+    execution_adapter: jvm
+    execution_status: planned
+  - id: typescript
+    aliases: [ts]
+    kind: source
+    recall: true
+    execution_adapter: node
+    execution_status: planned
+  - id: javascript
+    aliases: [js, web3.js]
+    kind: source
+    recall: true
+    execution_adapter: node-or-browser
+    execution_status: planned
+  - id: csharp
+    aliases: [c#]
+    kind: source
+    recall: true
+    execution_adapter: dotnet-or-unity
+    execution_status: planned
+  - id: solidity
+    kind: source
+    recall: true
+    execution_adapter: evm-toolchain
+    execution_status: research
+  - id: sql
+    kind: query
+    recall: true
+    execution_adapter: database
+    execution_status: planned
+  - id: cobol
+    kind: source
+    recall: true
+    execution_adapter: cobol
+    execution_status: research
+  - id: fortran
+    kind: source
+    recall: true
+    execution_adapter: fortran
+    execution_status: research
+  - id: haskell
+    kind: source
+    recall: true
+    execution_adapter: haskell
+    execution_status: research
+  - id: ruby
+    aliases: [ruby-on-rails]
+    kind: source
+    recall: true
+    execution_adapter: ruby
+    execution_status: research
+  - id: shell
+    aliases: [bash, sh]
+    kind: source
+    recall: true
+    execution_adapter: shell
+    execution_status: restricted
+  - id: html
+    kind: source
+    recall: true
+    execution_adapter: browser
+    execution_status: planned
+  - id: css
+    kind: source
+    recall: true
+    execution_adapter: browser
+    execution_status: planned
+  - id: json
+    kind: data
+    recall: true
+    execution_adapter: null
+    execution_status: not_applicable
+  - id: json-schema
+    kind: schema
+    recall: true
+    execution_adapter: schema-validator
+    execution_status: active
+  - id: yaml
+    kind: config
+    recall: true
+    execution_adapter: null
+    execution_status: not_applicable
+  - id: toml
+    kind: config
+    recall: true
+    execution_adapter: null
+    execution_status: not_applicable
+  - id: markdown
+    aliases: [md]
+    kind: documentation
+    recall: true
+    execution_adapter: null
+    execution_status: not_applicable
+  - id: emoji-a++
+    aliases: [emoji-ascii++]
+    kind: workflow
+    recall: true
+    execution_adapter: alchemy-compiler
+    execution_status: research
+  - id: tre-logic
+    kind: workflow
+    recall: true
+    execution_adapter: tre-rule-engine
+    execution_status: prototype
+  - id: plank
+    kind: source
+    recall: true
+    execution_adapter: null
+    execution_status: research
+
+technology_tags:
+  - fastapi
+  - flask
+  - asgi
+  - grpc
+  - websocket
+  - react
+  - vite
+  - astro
+  - three.js
+  - webxr
+  - qiskit
+  - vulkan
+  - android-ndk
+  - jni
+  - camerax
+  - docker
+  - sqlite
+  - surrealdb
+  - ipfs
+  - tensorflow-lite
+  - onnx
+  - cuda
+
+policy:
+  recall_and_execution_are_separate: true
+  preserve_original_content: true
+  hash_every_artifact: true
+  require_source_reference: true
+  require_authority_before_execution: true
+  require_receipt_for_execution: true

--- a/schemas/migi-code-artifact.v0.json
+++ b/schemas/migi-code-artifact.v0.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/QSTARMIGI/MIGI/schemas/migi-code-artifact.v0.json",
+  "title": "MIGI Code Artifact v0",
+  "description": "Language-neutral, provenance-carrying envelope for code, schemas, workflows, configuration, queries, and historical code recovered through RAG0SHOT recall.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "title",
+    "language",
+    "format",
+    "content",
+    "source",
+    "status",
+    "created_at",
+    "content_hash"
+  ],
+  "properties": {
+    "schema_version": { "const": "migi-code-artifact.v0" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "language": { "type": "string", "minLength": 1 },
+    "format": { "type": "string", "minLength": 1 },
+    "content": { "type": "string" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "uri"],
+      "properties": {
+        "kind": { "enum": ["chat", "log", "repository", "file", "generated", "external"] },
+        "uri": { "type": "string", "minLength": 1 },
+        "path": { "type": "string" },
+        "revision": { "type": "string" },
+        "conversation_id": { "type": "string" },
+        "message_id": { "type": "string" }
+      }
+    },
+    "status": {
+      "enum": ["concept", "specification", "prototype", "executable", "tested", "deprecated"]
+    },
+    "named_systems": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "tags": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "symbols": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "runtime_adapter": { "type": "string" },
+    "parent_artifact_id": { "type": "string" },
+    "receipt_id": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "content_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}


### PR DESCRIPTION
## Summary

This PR turns the architecture baseline into the first executable Rust workspace and adds a provenance-preserving code recall layer for historical MIGI/Mogo-Lab work.

### Verifiable core
- typed MUEF event model
- Tre Logic `+1 / 0 / -1`
- MIGIReceipt issuance
- SHA-256 input/output references
- schema-aligned lowercase source classification
- MIGI-CS-001 signal-loop tests

### RAG0SHOT code recall
- new `migi-recall` crate
- language-neutral `CodeArtifact` envelope
- provenance for chat, log, repository, file, generated, and external sources
- content hashing and integrity verification
- code status classification: concept/specification/prototype/executable/tested/deprecated
- named-system, tag, symbol, language, and source filters
- deterministic lexical/metadata recall baseline
- JSONL persistence
- Markdown/chat fenced-code importer with language alias normalization
- open-ended language identifiers so future formats can be recalled without changing the Rust enum

### Historical code vocabulary
Adds `provenance/code-formats.yaml` covering recurring MIGI formats including Rust, Python, C/C++, Kotlin/Java, TypeScript/JavaScript, C#, Solidity, SQL, COBOL, Fortran, Haskell, Ruby, Shell, HTML/CSS, JSON/JSON Schema/YAML/TOML/Markdown, Emoji A++/Emoji ASCII++, Tre Logic, and research formats.

### Architecture boundary
Recall and execution are explicitly separate. A recalled artifact can be inspected or compared without being runnable. Execution requires a registered runtime adapter, authority decision, and receipt.

### CI
The quality gate parses the schemas and runs `cargo test --workspace --all-targets`.

## Next
- ChainLog persistence
- exact artifact/hash/receipt lookup
- bulk conversation export ingestion command
- semantic/vector retrieval adapter
- CAMbus two-node transport
