### PR TITLE
feat: MIGI Genesis Node v0.1

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Check required files
         run: |
           test -f README.md
@@ -22,12 +25,19 @@ jobs:
           test -f SECURITY.md
           test -f docs/architecture/internal-operating-projects.md
           test -f docs/architecture/repository-roles.md
+          test -f docs/architecture/genesis-node-v0.1.md
           test -f docs/roadmap/mirror-seed-mvp.md
           test -f docs/adr/README.md
           test -f provenance/dependencies.yaml
           test -f schemas/muef-event.v0.json
           test -f schemas/migi-receipt.v0.json
+          test -f pyproject.toml
+          test -f migi/genesis.py
+          test -f tests/test_genesis.py
       - name: Validate JSON schemas parse
         run: |
-          python3 -m json.tool schemas/muef-event.v0.json >/dev/null
-          python3 -m json.tool schemas/migi-receipt.v0.json >/dev/null
+          python -m json.tool schemas/muef-event.v0.json >/dev/null
+          python -m json.tool schemas/migi-receipt.v0.json >/dev/null
+      - name: Run Genesis Node tests
+        run: |
+          PYTHONPATH=. python -W error::ResourceWarning -m unittest discover -s tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+.migi/
+*.db
+*.db-shm
+*.db-wal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Current Focus
 
-MIGI is in an architecture-and-MVP implementation phase. The first practical product path is **MIRROR SEED**: trusted mobile capture, local provenance, explainable analysis, human approval, and a replayable receipt trail.
+MIGI is in an architecture-and-MVP implementation phase. The executable core now starts with **Genesis Node v0.1**, which proves intent → authority → execution → verification → receipt → memory → recall. The first practical product path remains **MIRROR SEED**: trusted mobile capture, local provenance, explainable analysis, human approval, and a replayable receipt trail.
 
 MIGI is designed as a modular system rather than a single model or platform:
 
@@ -46,6 +46,7 @@ Receipt + Audit Trail
 ## Architecture Documentation
 
 - [Internal Operating Projects](docs/architecture/internal-operating-projects.md)
+- [Genesis Node v0.1](docs/architecture/genesis-node-v0.1.md)
 - [Repository Roles and Source Provenance](docs/architecture/repository-roles.md)
 - [MIRROR SEED MVP Backlog](docs/roadmap/mirror-seed-mvp.md)
 
@@ -79,6 +80,33 @@ Label output as derived or simulated
   ↓
 Show history and request human approval before consequential action
 ```
+
+## Genesis Node v0.1
+
+The first executable vertical slice lives in `migi/` and uses SQLite for durable local state. Core CLI operation requires only the Python standard library.
+
+```bash
+python -m migi.cli --db .migi/genesis.db inspect ./README.md
+python -m migi.cli --db .migi/genesis.db verify
+python -m migi.cli --db .migi/genesis.db recall README.md
+```
+
+The optional FastAPI surface matches the planned kernel boundary:
+
+```text
+GET  /status
+POST /execute
+GET  /receipts
+GET  /recall/{reference}
+```
+
+Run the acceptance suite with:
+
+```bash
+PYTHONPATH=. python -m unittest discover -s tests -v
+```
+
+Genesis v0.1 provides SHA-256 hash-chain integrity. Device identity signatures are deliberately deferred to the Android Keystore-backed MIRROR SEED milestone rather than being implied by the current code.
 
 ## Repository Status
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Receipt + Audit Trail
 |---|---|
 | **MIGI Kernel** | Coordinates intents, policy checks, task routing, and state updates. |
 | **MUEF** | MIGI Unified Event Framework; a shared event envelope across services and industry adapters. |
-| **MIGIReceipt** | Signed provenance object for captures, transformations, decisions, and actions. |
+| **MIGIReceipt** | Provenance object for captures, transformations, decisions, and actions; key-backed signing is layered on when available. |
 | **ChainLog** | Append-only lineage trail linking receipts and state transitions. |
 | **LUFITGuard** | Consent, scope, risk, budget, and tool-permission policy gate. |
 | **Tre Logic** | Explainable `+1 / 0 / -1` authorization state: proceed, hold, or deny. |

--- a/docs/architecture/genesis-node-v0.1.md
+++ b/docs/architecture/genesis-node-v0.1.md
@@ -1,0 +1,98 @@
+# MIGI Genesis Node v0.1
+
+**Purpose:** prove the smallest executable MIGI loop end-to-end.
+
+```text
+Intent
+  ↓
+LUFITGuard + Tre Logic
+  ↓
+Execution
+  ↓
+Verification
+  ↓
+MIGIReceipt + SHA-256 ChainLog
+  ↓
+Structured Memory
+  ↓
+Receipt-grounded Recall
+```
+
+## Frozen v0.1 objects
+
+- `MIGIIntent`
+- `MIGIArtifact`
+- `MIGIAuthority`
+- `MIGIExecution`
+- `MIGIReceipt`
+- `MIGIMemory`
+
+The implementation intentionally keeps these objects small. Domain-specific systems such as Alchemy, manufacturing, MIRROR SEED, QSTAR, HBC, and CAMBUS should integrate through these boundaries rather than bypassing them.
+
+## First executable capability
+
+Genesis v0.1 supports one operation: `artifact.inspect`.
+
+Given a user-selected local file, the node:
+
+1. stores the user's intent;
+2. checks explicit read scope and allowed-root policy;
+3. returns Tre Logic `+1`, `0`, or `-1` with a reason code;
+4. on `+1`, computes SHA-256, byte size, and media type;
+5. recomputes the file hash and size as execution verification;
+6. creates a `migi-receipt.v0`-compatible receipt;
+7. chains the receipt to the prior receipt using SHA-256;
+8. stores a structured memory record; and
+9. reconstructs history later from receipts plus linked execution records.
+
+A denied or held request is also receipted, but no file content is read by the execution engine.
+
+## Security boundary
+
+The API allows inspection only beneath `MIGI_ALLOWED_ROOT` (default: server working directory). Merely remembering a path or command does not authorize it.
+
+Genesis v0.1 provides **hash-chain integrity, not identity signatures**. Android Keystore-backed signing is a later MIRROR SEED milestone and must not be implied by this version.
+
+## Deterministic hashing
+
+The receipt chain uses deterministic JSON encoding with sorted keys and rejects floating-point values in hashed records. This is a deliberately narrow Genesis canonical format and does **not** claim full RFC 8785/JCS conformance.
+
+## Run locally
+
+Core CLI uses only the Python standard library:
+
+```bash
+python -m migi.cli --db .migi/genesis.db inspect ./README.md
+python -m migi.cli --db .migi/genesis.db verify
+python -m migi.cli --db .migi/genesis.db recall README.md
+```
+
+Optional API:
+
+```bash
+pip install -e '.[api]'
+MIGI_ALLOWED_ROOT="$PWD" uvicorn migi.api:app --host 127.0.0.1 --port 8000
+```
+
+Endpoints:
+
+```text
+GET  /status
+POST /execute
+GET  /receipts
+GET  /recall/{reference}
+```
+
+## Acceptance test
+
+A build passes Genesis v0.1 when a real artifact can be explicitly authorized, inspected, independently verified, receipted into a valid chain, stored, and later reconstructed from durable records.
+
+Run:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Next milestone
+
+After this vertical slice is stable, the next extension is MIRROR SEED capture plus Android Keystore signatures so a phone can create signed original-observation receipts before any AI-derived transformation occurs.

--- a/migi/__init__.py
+++ b/migi/__init__.py
@@ -1,0 +1,25 @@
+"""MIGI Core executable modules."""
+
+from .genesis import GenesisNode
+from .models import (
+    MIGIArtifact,
+    MIGIAuthority,
+    MIGIExecution,
+    MIGIIntent,
+    MIGIMemory,
+    MIGIReceipt,
+    SourceClass,
+    TreLogic,
+)
+
+__all__ = [
+    "GenesisNode",
+    "MIGIIntent",
+    "MIGIArtifact",
+    "MIGIAuthority",
+    "MIGIExecution",
+    "MIGIReceipt",
+    "MIGIMemory",
+    "TreLogic",
+    "SourceClass",
+]

--- a/migi/api.py
+++ b/migi/api.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .genesis import GenesisNode
+
+
+class ExecuteRequest(BaseModel):
+    action: str = Field(default="artifact.inspect")
+    target: str
+    actor_id: str = "local-user"
+    consent_scope: str = "local.read"
+
+
+DB_PATH = os.environ.get("MIGI_DB_PATH", ".migi/genesis.db")
+ALLOWED_ROOT = Path(os.environ.get("MIGI_ALLOWED_ROOT", Path.cwd())).expanduser().resolve()
+node = GenesisNode(DB_PATH, allowed_roots=[ALLOWED_ROOT])
+app = FastAPI(title="MIGI Genesis Node", version=node.VERSION)
+
+
+@app.get("/status")
+def status():
+    return node.status()
+
+
+@app.post("/execute")
+def execute(request: ExecuteRequest):
+    if request.action != "artifact.inspect":
+        raise HTTPException(status_code=400, detail="Genesis v0.1 only supports artifact.inspect")
+    result = node.inspect_artifact(
+        request.target,
+        actor_id=request.actor_id,
+        consent_scope=request.consent_scope,
+    )
+    return result
+
+
+@app.get("/receipts")
+def receipts():
+    return {"chain": node.store.verify_chain(), "receipts": node.store.receipts()}
+
+
+@app.get("/recall/{reference}")
+def recall(reference: str):
+    result = node.recall_artifact(reference)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    return result

--- a/migi/authority.py
+++ b/migi/authority.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .models import MIGIAuthority, MIGIIntent, TreLogic
+from .util import new_id, utc_now
+
+
+@dataclass(frozen=True)
+class AuthorityDecision:
+    authority: MIGIAuthority
+
+    @property
+    def allowed(self) -> bool:
+        return self.authority.tre_logic == TreLogic.ALLOW.value
+
+
+class LUFITGuard:
+    """Minimal Genesis policy gate.
+
+    v0.1 only authorizes a read-only artifact inspection operation and only when
+    the target is inside an explicitly allowed root.
+    """
+
+    ALLOWED_ACTIONS = {"artifact.inspect"}
+    ALLOWED_SCOPES = {"local.read", "private.local.read"}
+
+    def __init__(self, allowed_roots: Iterable[Path]):
+        roots = [Path(root).expanduser().resolve() for root in allowed_roots]
+        if not roots:
+            raise ValueError("At least one allowed root is required")
+        self.allowed_roots = tuple(roots)
+
+    def evaluate(self, intent: MIGIIntent) -> AuthorityDecision:
+        state = TreLogic.ALLOW
+        reason = "authority.explicit_local_read"
+
+        if intent.action not in self.ALLOWED_ACTIONS:
+            state = TreLogic.DENY
+            reason = "policy.action_not_allowlisted"
+        elif intent.consent_scope not in self.ALLOWED_SCOPES:
+            state = TreLogic.HOLD
+            reason = "authority.explicit_consent_required"
+        else:
+            target = Path(intent.target_ref).expanduser().resolve()
+            if not target.exists() or not target.is_file():
+                state = TreLogic.HOLD
+                reason = "target.file_not_available"
+            elif not any(_is_within(target, root) for root in self.allowed_roots):
+                state = TreLogic.DENY
+                reason = "policy.target_outside_allowed_root"
+
+        authority = MIGIAuthority(
+            authority_id=new_id("auth"),
+            decided_at=utc_now(),
+            intent_id=intent.intent_id,
+            tre_logic=state.value,
+            reason_code=reason,
+            consent_scope=intent.consent_scope,
+        )
+        return AuthorityDecision(authority=authority)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/migi/canonical.py
+++ b/migi/canonical.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def _reject_float(value: Any) -> None:
+    if isinstance(value, float):
+        raise TypeError("Genesis canonical JSON forbids floating-point values in hashed records")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("Canonical JSON object keys must be strings")
+            _reject_float(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _reject_float(item)
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for Genesis v0.1 records.
+
+    v0.1 intentionally rejects floats so the hash input is stable across runtimes.
+    This is a narrow deterministic format, not a claim of full RFC 8785 support.
+    """
+    _reject_float(value)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def chained_hash(previous_hash: str, payload: Any) -> str:
+    material = previous_hash.encode("ascii") + b"\n" + canonical_json_bytes(payload)
+    return sha256_hex(material)

--- a/migi/cli.py
+++ b/migi/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .genesis import GenesisNode
+
+
+def _print(value) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="migi-genesis")
+    parser.add_argument("--db", default=".migi/genesis.db", help="SQLite ChainLog path")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    inspect_cmd = sub.add_parser("inspect", help="Inspect and receipt a local artifact")
+    inspect_cmd.add_argument("path")
+    inspect_cmd.add_argument("--actor", default="local-user")
+    inspect_cmd.add_argument("--scope", default="local.read")
+
+    recall_cmd = sub.add_parser("recall", help="Reconstruct artifact history from receipts")
+    recall_cmd.add_argument("reference", help="Artifact ID, SHA-256, path, or filename")
+
+    sub.add_parser("verify", help="Verify the receipt hash chain")
+    sub.add_parser("status", help="Show Genesis Node status")
+
+    args = parser.parse_args()
+
+    if args.command == "inspect":
+        path = Path(args.path).expanduser().resolve()
+        node = GenesisNode(args.db, allowed_roots=[path.parent])
+        result = node.inspect_artifact(path, actor_id=args.actor, consent_scope=args.scope)
+        _print(result)
+        return 0 if result["authority"]["tre_logic"] == "+1" else 2
+
+    node = GenesisNode(args.db, allowed_roots=[Path.cwd()])
+    if args.command == "recall":
+        result = node.recall_artifact(args.reference)
+        _print(result)
+        return 0 if result is not None else 1
+    if args.command == "verify":
+        result = node.store.verify_chain()
+        _print(result)
+        return 0 if result["valid"] else 1
+    if args.command == "status":
+        _print(node.status())
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migi/genesis.py
+++ b/migi/genesis.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from pathlib import Path
+from typing import Any, Iterable
+
+from .authority import LUFITGuard
+from .models import (
+    MIGIArtifact,
+    MIGIExecution,
+    MIGIIntent,
+    MIGIMemory,
+    MIGIReceipt,
+    SourceClass,
+)
+from .storage import GenesisStore
+from .util import new_id, utc_now
+
+
+class GenesisNode:
+    """MIGI Genesis Node v0.1.
+
+    Implements one accountable vertical slice:
+    intent -> authority -> execution -> verification -> receipt -> memory -> recall.
+    """
+
+    VERSION = "0.1.0"
+
+    def __init__(self, db_path: str | Path, allowed_roots: Iterable[str | Path] | None = None):
+        roots = list(allowed_roots or [Path.cwd()])
+        self.store = GenesisStore(db_path)
+        self.guard = LUFITGuard(Path(root) for root in roots)
+
+    def status(self) -> dict[str, Any]:
+        verification = self.store.verify_chain()
+        return {
+            "service": "migi-genesis-node",
+            "version": self.VERSION,
+            "receipt_chain": verification,
+            "capabilities": ["artifact.inspect", "receipt.verify", "artifact.recall"],
+        }
+
+    def inspect_artifact(
+        self,
+        path: str | Path,
+        *,
+        actor_id: str = "local-user",
+        consent_scope: str = "local.read",
+    ) -> dict[str, Any]:
+        target = Path(path).expanduser().resolve()
+        intent = MIGIIntent(
+            intent_id=new_id("intent"),
+            created_at=utc_now(),
+            actor_id=actor_id,
+            action="artifact.inspect",
+            target_ref=str(target),
+            consent_scope=consent_scope,
+            metadata={"requested_via": "genesis.v0.1"},
+        )
+        self.store.put("intent", intent.intent_id, intent.created_at, intent.to_dict())
+
+        decision = self.guard.evaluate(intent)
+        authority = decision.authority
+        self.store.put("authority", authority.authority_id, authority.decided_at, authority.to_dict())
+
+        if not decision.allowed:
+            return self._record_non_execution(intent, authority)
+
+        started_at = utc_now()
+        digest, size_bytes = _hash_file(target)
+        media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+        artifact = MIGIArtifact(
+            artifact_id=new_id("artifact"),
+            observed_at=utc_now(),
+            path=str(target),
+            sha256=digest,
+            size_bytes=size_bytes,
+            media_type=media_type,
+        )
+        self.store.put("artifact", artifact.artifact_id, artifact.observed_at, artifact.to_dict())
+
+        verify_digest, verify_size = _hash_file(target)
+        verification = {
+            "sha256_match": verify_digest == digest,
+            "size_match": verify_size == size_bytes,
+        }
+        success = all(verification.values())
+        execution = MIGIExecution(
+            execution_id=new_id("exec"),
+            started_at=started_at,
+            completed_at=utc_now(),
+            intent_id=intent.intent_id,
+            authority_id=authority.authority_id,
+            executor="migi.genesis.artifact_inspector",
+            operation="artifact.inspect",
+            success=success,
+            output={
+                "artifact_id": artifact.artifact_id,
+                "sha256": artifact.sha256,
+                "size_bytes": artifact.size_bytes,
+                "media_type": artifact.media_type,
+            },
+            verification=verification,
+        )
+        self.store.put("execution", execution.execution_id, execution.completed_at, execution.to_dict())
+
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=execution.execution_id,
+            source_class=SourceClass.EXECUTED.value,
+            output_ref=artifact.artifact_id,
+            metadata={
+                "execution_ref": execution.execution_id,
+                "executor": execution.executor,
+                "verified": success,
+            },
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=artifact.artifact_id,
+            receipt_id=receipt.receipt_id,
+            kind="artifact.inspect.completed",
+            summary=(
+                f"Inspected {target.name}; SHA-256 {artifact.sha256}; "
+                f"{artifact.size_bytes} bytes; media type {artifact.media_type}."
+            ),
+            facts={
+                "artifact_sha256": artifact.sha256,
+                "execution_ref": execution.execution_id,
+                "authority_ref": authority.authority_id,
+                "verified": success,
+            },
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+
+        return {
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": execution.to_dict(),
+            "artifact": artifact.to_dict(),
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+        }
+
+    def recall_artifact(self, reference: str) -> dict[str, Any] | None:
+        artifact = self._find_artifact(reference)
+        if artifact is None:
+            return None
+
+        receipts = [r for r in self.store.receipts() if r.get("output_ref") == artifact["artifact_id"]]
+        memories = [m for m in self.store.list_kind("memory") if m.get("subject_ref") == artifact["artifact_id"]]
+
+        reconstructed: list[dict[str, Any]] = []
+        for receipt in receipts:
+            intent = self.store.get(receipt["intent_ref"])
+            execution_ref = receipt.get("metadata", {}).get("execution_ref")
+            execution = self.store.get(execution_ref) if execution_ref else None
+            reconstructed.append(
+                {
+                    "receipt": receipt,
+                    "intent": intent,
+                    "execution": execution,
+                }
+            )
+
+        return {
+            "artifact": artifact,
+            "history": reconstructed,
+            "memories": memories,
+            "chain": self.store.verify_chain(),
+        }
+
+    def _find_artifact(self, reference: str) -> dict[str, Any] | None:
+        for artifact in self.store.list_kind("artifact"):
+            if reference in {
+                artifact.get("artifact_id"),
+                artifact.get("sha256"),
+                artifact.get("path"),
+                Path(str(artifact.get("path", ""))).name,
+            }:
+                return artifact
+        return None
+
+    def _record_non_execution(self, intent: MIGIIntent, authority) -> dict[str, Any]:
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=authority.authority_id,
+            source_class=SourceClass.PROPOSED.value,
+            output_ref=authority.authority_id,
+            metadata={"executed": False},
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=intent.intent_id,
+            receipt_id=receipt.receipt_id,
+            kind="artifact.inspect.not_executed",
+            summary=f"Artifact inspection did not execute: {authority.reason_code}.",
+            facts={"tre_logic": authority.tre_logic, "reason_code": authority.reason_code},
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+        return {
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": None,
+            "artifact": None,
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+        }
+
+    def _make_receipt(
+        self,
+        *,
+        intent: MIGIIntent,
+        authority,
+        event_id: str,
+        source_class: str,
+        output_ref: str,
+        metadata: dict[str, Any],
+    ) -> MIGIReceipt:
+        return MIGIReceipt(
+            schema_version="migi-receipt.v0",
+            receipt_id=new_id("receipt"),
+            issued_at=utc_now(),
+            event_id=event_id,
+            source_class=source_class,
+            intent_ref=intent.intent_id,
+            output_ref=output_ref,
+            previous_receipt_ref=self.store.latest_receipt_hash(),
+            authority={
+                "tre_logic": authority.tre_logic,
+                "reason_code": authority.reason_code,
+                "consent_scope": authority.consent_scope,
+            },
+            metadata=metadata,
+        )
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size

--- a/migi/models.py
+++ b/migi/models.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TreLogic(str, Enum):
+    ALLOW = "+1"
+    HOLD = "0"
+    DENY = "-1"
+
+
+class SourceClass(str, Enum):
+    ORIGINAL = "original"
+    OBSERVED = "observed"
+    DERIVED = "derived"
+    SIMULATED = "simulated"
+    PROPOSED = "proposed"
+    AUTHORIZED = "authorized"
+    EXECUTED = "executed"
+
+
+class Serializable:
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MIGIIntent(Serializable):
+    intent_id: str
+    created_at: str
+    actor_id: str
+    action: str
+    target_ref: str
+    consent_scope: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MIGIArtifact(Serializable):
+    artifact_id: str
+    observed_at: str
+    path: str
+    sha256: str
+    size_bytes: int
+    media_type: str
+    source_class: str = SourceClass.OBSERVED.value
+
+
+@dataclass(frozen=True)
+class MIGIAuthority(Serializable):
+    authority_id: str
+    decided_at: str
+    intent_id: str
+    tre_logic: str
+    reason_code: str
+    consent_scope: str
+
+
+@dataclass(frozen=True)
+class MIGIExecution(Serializable):
+    execution_id: str
+    started_at: str
+    completed_at: str
+    intent_id: str
+    authority_id: str
+    executor: str
+    operation: str
+    success: bool
+    output: dict[str, Any] = field(default_factory=dict)
+    verification: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MIGIReceipt(Serializable):
+    schema_version: str
+    receipt_id: str
+    issued_at: str
+    event_id: str
+    source_class: str
+    intent_ref: str
+    output_ref: str
+    previous_receipt_ref: str
+    authority: dict[str, str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MIGIMemory(Serializable):
+    memory_id: str
+    created_at: str
+    subject_ref: str
+    receipt_id: str
+    kind: str
+    summary: str
+    facts: dict[str, Any] = field(default_factory=dict)

--- a/migi/storage.py
+++ b/migi/storage.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .canonical import chained_hash
+from .models import MIGIReceipt
+
+
+class GenesisStore:
+    def __init__(self, db_path: str | Path):
+        self.db_path = str(db_path)
+        Path(self.db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        return conn
+
+    @contextmanager
+    def _session(self):
+        conn = self._connect()
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _init_schema(self) -> None:
+        with self._session() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS objects (
+                    kind TEXT NOT NULL,
+                    object_id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_objects_kind_created
+                ON objects(kind, created_at);
+
+                CREATE TABLE IF NOT EXISTS receipt_chain (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    receipt_id TEXT NOT NULL UNIQUE,
+                    receipt_hash TEXT NOT NULL UNIQUE,
+                    previous_receipt_hash TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+                """
+            )
+
+    def put(self, kind: str, object_id: str, created_at: str, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        with self._session() as conn:
+            conn.execute(
+                "INSERT INTO objects(kind, object_id, created_at, payload_json) VALUES (?, ?, ?, ?)",
+                (kind, object_id, created_at, encoded),
+            )
+
+    def get(self, object_id: str) -> dict[str, Any] | None:
+        with self._session() as conn:
+            row = conn.execute(
+                "SELECT kind, object_id, created_at, payload_json FROM objects WHERE object_id = ?",
+                (object_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {"kind": row["kind"], **json.loads(row["payload_json"])}
+
+    def list_kind(self, kind: str) -> list[dict[str, Any]]:
+        with self._session() as conn:
+            rows = conn.execute(
+                "SELECT payload_json FROM objects WHERE kind = ? ORDER BY created_at, object_id",
+                (kind,),
+            ).fetchall()
+        return [json.loads(row["payload_json"]) for row in rows]
+
+    def latest_receipt_hash(self) -> str:
+        with self._session() as conn:
+            row = conn.execute(
+                "SELECT receipt_hash FROM receipt_chain ORDER BY sequence DESC LIMIT 1"
+            ).fetchone()
+        return "" if row is None else str(row["receipt_hash"])
+
+    def append_receipt(self, receipt: MIGIReceipt) -> str:
+        payload = receipt.to_dict()
+        previous = self.latest_receipt_hash()
+        if payload["previous_receipt_ref"] != previous:
+            raise ValueError("Receipt previous_receipt_ref does not match current chain head")
+        receipt_hash = chained_hash(previous, payload)
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        with self._session() as conn:
+            conn.execute(
+                """
+                INSERT INTO receipt_chain(receipt_id, receipt_hash, previous_receipt_hash, payload_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (receipt.receipt_id, receipt_hash, previous, encoded),
+            )
+        return receipt_hash
+
+    def receipts(self) -> list[dict[str, Any]]:
+        with self._session() as conn:
+            rows = conn.execute(
+                """
+                SELECT sequence, receipt_id, receipt_hash, previous_receipt_hash, payload_json
+                FROM receipt_chain ORDER BY sequence
+                """
+            ).fetchall()
+        return [
+            {
+                "sequence": row["sequence"],
+                "receipt_hash": row["receipt_hash"],
+                "previous_receipt_hash": row["previous_receipt_hash"],
+                **json.loads(row["payload_json"]),
+            }
+            for row in rows
+        ]
+
+    def verify_chain(self) -> dict[str, Any]:
+        previous = ""
+        checked = 0
+        for item in self.receipts():
+            payload = {
+                key: value
+                for key, value in item.items()
+                if key not in {"sequence", "receipt_hash", "previous_receipt_hash"}
+            }
+            if item["previous_receipt_hash"] != previous:
+                return {"valid": False, "checked": checked, "reason": "stored_previous_mismatch"}
+            if payload["previous_receipt_ref"] != previous:
+                return {"valid": False, "checked": checked, "reason": "payload_previous_mismatch"}
+            expected = chained_hash(previous, payload)
+            if expected != item["receipt_hash"]:
+                return {"valid": False, "checked": checked, "reason": "receipt_hash_mismatch"}
+            previous = item["receipt_hash"]
+            checked += 1
+        return {"valid": True, "checked": checked, "head": previous}

--- a/migi/util.py
+++ b/migi/util.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "migi-core"
+version = "0.1.0"
+description = "MIGI Genesis Node: accountable intent-to-receipt execution core"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+
+[project.optional-dependencies]
+api = [
+  "fastapi>=0.115,<1.0",
+  "uvicorn>=0.30,<1.0",
+]
+
+[project.scripts]
+migi-genesis = "migi.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["migi*"]

--- a/tests/test_genesis.py
+++ b/tests/test_genesis.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from migi.genesis import GenesisNode
+
+
+class GenesisNodeTests(unittest.TestCase):
+    def test_end_to_end_receipt_memory_recall(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_path = root / "sample.txt"
+            artifact_path.write_text("MIGI Genesis\n", encoding="utf-8")
+            node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+
+            result = node.inspect_artifact(artifact_path, actor_id="tester")
+
+            self.assertEqual(result["authority"]["tre_logic"], "+1")
+            self.assertTrue(result["execution"]["success"])
+            self.assertTrue(result["execution"]["verification"]["sha256_match"])
+            self.assertTrue(result["execution"]["verification"]["size_match"])
+            self.assertEqual(result["receipt"]["output_ref"], result["artifact"]["artifact_id"])
+
+            chain = node.store.verify_chain()
+            self.assertTrue(chain["valid"])
+            self.assertEqual(chain["checked"], 1)
+
+            recalled = node.recall_artifact(result["artifact"]["sha256"])
+            self.assertIsNotNone(recalled)
+            self.assertEqual(recalled["artifact"]["artifact_id"], result["artifact"]["artifact_id"])
+            self.assertEqual(recalled["history"][0]["intent"]["action"], "artifact.inspect")
+            self.assertEqual(
+                recalled["history"][0]["execution"]["execution_id"],
+                result["execution"]["execution_id"],
+            )
+
+    def test_unapproved_scope_holds_and_does_not_read(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_path = root / "sample.txt"
+            artifact_path.write_text("private", encoding="utf-8")
+            node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+
+            result = node.inspect_artifact(artifact_path, consent_scope="unspecified")
+
+            self.assertEqual(result["authority"]["tre_logic"], "0")
+            self.assertIsNone(result["execution"])
+            self.assertIsNone(result["artifact"])
+            self.assertEqual(node.store.verify_chain()["checked"], 1)
+
+    def test_target_outside_root_is_denied(self):
+        with tempfile.TemporaryDirectory() as allowed_dir, tempfile.TemporaryDirectory() as other_dir:
+            allowed = Path(allowed_dir)
+            target = Path(other_dir) / "outside.txt"
+            target.write_text("outside", encoding="utf-8")
+            node = GenesisNode(allowed / "genesis.db", allowed_roots=[allowed])
+
+            result = node.inspect_artifact(target)
+
+            self.assertEqual(result["authority"]["tre_logic"], "-1")
+            self.assertEqual(result["authority"]["reason_code"], "policy.target_outside_allowed_root")
+            self.assertIsNone(result["execution"])
+
+    def test_second_receipt_links_to_first_hash(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first = root / "one.txt"
+            second = root / "two.txt"
+            first.write_text("one", encoding="utf-8")
+            second.write_text("two", encoding="utf-8")
+            node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+
+            r1 = node.inspect_artifact(first)
+            r2 = node.inspect_artifact(second)
+
+            self.assertEqual(r2["receipt"]["previous_receipt_ref"], r1["receipt_hash"])
+            verification = node.store.verify_chain()
+            self.assertTrue(verification["valid"])
+            self.assertEqual(verification["checked"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_genesis.py
+++ b/tests/test_genesis.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+from contextlib import closing
 import tempfile
 import unittest
 from pathlib import Path
@@ -79,6 +82,33 @@ class GenesisNodeTests(unittest.TestCase):
             verification = node.store.verify_chain()
             self.assertTrue(verification["valid"])
             self.assertEqual(verification["checked"], 2)
+
+    def test_receipt_tampering_is_detected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "evidence.txt"
+            target.write_text("original evidence", encoding="utf-8")
+            db_path = root / "genesis.db"
+            node = GenesisNode(db_path, allowed_roots=[root])
+
+            node.inspect_artifact(target)
+            self.assertTrue(node.store.verify_chain()["valid"])
+
+            with closing(sqlite3.connect(db_path)) as conn:
+                with conn:
+                    row = conn.execute(
+                        "SELECT sequence, payload_json FROM receipt_chain ORDER BY sequence LIMIT 1"
+                    ).fetchone()
+                    payload = json.loads(row[1])
+                    payload["metadata"]["verified"] = False
+                    conn.execute(
+                        "UPDATE receipt_chain SET payload_json = ? WHERE sequence = ?",
+                        (json.dumps(payload, sort_keys=True, separators=(",", ":")), row[0]),
+                    )
+
+            verification = node.store.verify_chain()
+            self.assertFalse(verification["valid"])
+            self.assertEqual(verification["reason"], "receipt_hash_mismatch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements the first executable MIGI vertical slice:

`Intent → LUFITGuard/Tre Logic → Execution → Verification → MIGIReceipt → ChainLog → Structured Memory → Receipt-grounded Recall`

## What this adds

- six frozen Genesis core objects: `MIGIIntent`, `MIGIArtifact`, `MIGIAuthority`, `MIGIExecution`, `MIGIReceipt`, `MIGIMemory`
- read-only `artifact.inspect` capability
- Tre Logic `+1 / 0 / -1` decisions with reason codes
- allowed-root policy boundary so recalled paths do not become authority
- SQLite durable object store and append-only receipt chain
- deterministic SHA-256 receipt chaining
- independent hash/size verification before recording success
- receipt-grounded artifact recall
- CLI commands for inspect, verify, recall, and status
- optional FastAPI `/status`, `/execute`, `/receipts`, and `/recall/{reference}` surface
- Genesis architecture documentation and README quick start
- CI acceptance tests

## Validation

Local acceptance suite passes 5/5 tests with ResourceWarnings treated as errors:

- successful inspect → verify → receipt → memory → recall
- missing consent returns Tre Logic `0` with no execution
- target outside allowed root returns `-1` with no execution
- second receipt links cryptographically to the first receipt hash
- deliberate stored-receipt tampering is detected as `receipt_hash_mismatch`

The repository MIGI Quality Gate also runs the Genesis suite on pull requests.

## Security / provenance boundary

Genesis v0.1 provides SHA-256 hash-chain integrity only. It deliberately does **not** claim device identity signatures or full RFC 8785/JCS conformance. Android Keystore-backed signing is the next MIRROR SEED milestone.
