### PR TITLE
feat: Genesis CAMbus + deterministic replay v0.2

### DIFF
--- a/docs/architecture/cambus-replay-v0.2.md
+++ b/docs/architecture/cambus-replay-v0.2.md
@@ -1,0 +1,117 @@
+# CAMbus + Deterministic Replay v0.2
+
+> Status: experimental vertical slice
+
+Genesis v0.2 extends the accountable core with a transport-neutral semantic packet and a replayable MUEF state transition.
+
+## Invariant
+
+```text
+Network receipt != authorization
+```
+
+A CAMbus packet may deliver a MUEF event to a node. The receiving node must still create an intent and pass LUFITGuard/Tre Logic before the event can become an executed state transition.
+
+## Executable path
+
+```text
+Node A
+  |
+  | SymbolPacket / CAMbus v0
+  v
+Node B
+  |
+  v
+MUEF validation
+  |
+  v
+MIGIIntent(state.patch)
+  |
+  v
+LUFITGuard
+  |             \
+ +1              0 / -1
+  |                \
+  v                 v
+execution        no execution
+  |                 |
+  +--------+--------+
+           v
+      MIGIReceipt
+           |
+           v
+      receipt chain
+           |
+           v
+ deterministic replay
+```
+
+## MUEF state patch
+
+v0.2 executes one deliberately narrow event type:
+
+```json
+{
+  "schema_version": "muef.v0",
+  "event_type": "migi.state.patch",
+  "payload": {
+    "state_patch": {
+      "mode": "active"
+    }
+  }
+}
+```
+
+A JSON `null` value deletes a state key during replay. All other values replace the key. Replay applies patch keys in sorted order and only applies events that have an `executed` receipt with Tre Logic `+1`.
+
+## Authority
+
+`state.patch` requires:
+
+```text
+consent_scope = local.state.write
+or
+consent_scope = private.local.state.write
+```
+
+and the internal intent target must be a `state:` reference.
+
+CAMbus does not bypass this policy.
+
+## CAMbus v0
+
+The initial wire representation is canonical JSON with a 4-byte network-order length prefix.
+
+`SymbolPacket` carries:
+
+- protocol version
+- packet ID
+- correlation ID
+- source node
+- destination node
+- QoS profile
+- one MUEF event
+
+The first adapter uses TCP only to prove the transport boundary. CAN, WebSocket, optical/LiFi, or other adapters can implement the same packet contract later.
+
+## Replay output
+
+Replay returns:
+
+- materialized state
+- count of applied events
+- count of preserved but skipped events
+- verified receipt-chain head
+- deterministic SHA-256 state hash
+
+This lets two implementations compare a replay result by state hash without treating the materialized state store as the source of truth.
+
+## Acceptance criteria
+
+1. MUEF event validation passes.
+2. CAMbus round-trip preserves event identity.
+3. `state.patch` requires explicit local state-write authority.
+4. Held/denied events remain stored but do not alter replay state.
+5. Executed events produce receipts linked into the existing Genesis receipt chain.
+6. Replay refuses to operate when the receipt chain is invalid.
+7. A two-node localhost test sends a MUEF event over CAMbus and reconstructs the resulting state on Node B.

--- a/migi/authority.py
+++ b/migi/authority.py
@@ -20,12 +20,15 @@ class AuthorityDecision:
 class LUFITGuard:
     """Minimal Genesis policy gate.
 
-    v0.1 only authorizes a read-only artifact inspection operation and only when
-    the target is inside an explicitly allowed root.
+    v0.2 keeps the original read-only artifact inspection policy and adds one
+    tightly scoped state transition: `state.patch` with explicit local write
+    consent and a synthetic `state:` target. Network transport never grants
+    authority by itself.
     """
 
-    ALLOWED_ACTIONS = {"artifact.inspect"}
-    ALLOWED_SCOPES = {"local.read", "private.local.read"}
+    ALLOWED_ACTIONS = {"artifact.inspect", "state.patch"}
+    ARTIFACT_SCOPES = {"local.read", "private.local.read"}
+    STATE_SCOPES = {"local.state.write", "private.local.state.write"}
 
     def __init__(self, allowed_roots: Iterable[Path]):
         roots = [Path(root).expanduser().resolve() for root in allowed_roots]
@@ -34,24 +37,35 @@ class LUFITGuard:
         self.allowed_roots = tuple(roots)
 
     def evaluate(self, intent: MIGIIntent) -> AuthorityDecision:
-        state = TreLogic.ALLOW
-        reason = "authority.explicit_local_read"
-
         if intent.action not in self.ALLOWED_ACTIONS:
-            state = TreLogic.DENY
-            reason = "policy.action_not_allowlisted"
-        elif intent.consent_scope not in self.ALLOWED_SCOPES:
-            state = TreLogic.HOLD
-            reason = "authority.explicit_consent_required"
-        else:
-            target = Path(intent.target_ref).expanduser().resolve()
-            if not target.exists() or not target.is_file():
-                state = TreLogic.HOLD
-                reason = "target.file_not_available"
-            elif not any(_is_within(target, root) for root in self.allowed_roots):
-                state = TreLogic.DENY
-                reason = "policy.target_outside_allowed_root"
+            return self._decision(intent, TreLogic.DENY, "policy.action_not_allowlisted")
 
+        if intent.action == "artifact.inspect":
+            return self._evaluate_artifact_inspect(intent)
+        if intent.action == "state.patch":
+            return self._evaluate_state_patch(intent)
+
+        return self._decision(intent, TreLogic.DENY, "policy.action_not_allowlisted")
+
+    def _evaluate_artifact_inspect(self, intent: MIGIIntent) -> AuthorityDecision:
+        if intent.consent_scope not in self.ARTIFACT_SCOPES:
+            return self._decision(intent, TreLogic.HOLD, "authority.explicit_consent_required")
+
+        target = Path(intent.target_ref).expanduser().resolve()
+        if not target.exists() or not target.is_file():
+            return self._decision(intent, TreLogic.HOLD, "target.file_not_available")
+        if not any(_is_within(target, root) for root in self.allowed_roots):
+            return self._decision(intent, TreLogic.DENY, "policy.target_outside_allowed_root")
+        return self._decision(intent, TreLogic.ALLOW, "authority.explicit_local_read")
+
+    def _evaluate_state_patch(self, intent: MIGIIntent) -> AuthorityDecision:
+        if intent.consent_scope not in self.STATE_SCOPES:
+            return self._decision(intent, TreLogic.HOLD, "authority.explicit_state_write_required")
+        if not intent.target_ref.startswith("state:"):
+            return self._decision(intent, TreLogic.DENY, "policy.invalid_state_target")
+        return self._decision(intent, TreLogic.ALLOW, "authority.explicit_local_state_write")
+
+    def _decision(self, intent: MIGIIntent, state: TreLogic, reason: str) -> AuthorityDecision:
         authority = MIGIAuthority(
             authority_id=new_id("auth"),
             decided_at=utc_now(),

--- a/migi/cambus.py
+++ b/migi/cambus.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .canonical import canonical_json_bytes
+from .events import MUEFEvent
+from .util import new_id
+
+CAMBUS_PROTOCOL_VERSION = "cambus.v0"
+MAX_FRAME_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class QoSProfile:
+    delivery: str = "reliable"
+    priority: int = 128
+    max_latency_ms: int | None = None
+    local_only: bool = False
+
+    def validate(self) -> None:
+        if self.delivery not in {"best_effort", "reliable", "control"}:
+            raise ValueError("Unsupported CAMbus delivery class")
+        if not 0 <= self.priority <= 255:
+            raise ValueError("CAMbus priority must be between 0 and 255")
+        if self.max_latency_ms is not None and self.max_latency_ms < 0:
+            raise ValueError("CAMbus max_latency_ms cannot be negative")
+
+
+@dataclass(frozen=True)
+class SymbolPacket:
+    protocol_version: str
+    packet_id: str
+    correlation_id: str
+    source_node: str
+    destination_node: str
+    event: MUEFEvent
+    qos: QoSProfile = field(default_factory=QoSProfile)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source_node: str,
+        destination_node: str,
+        event: MUEFEvent,
+        qos: QoSProfile | None = None,
+        correlation_id: str | None = None,
+    ) -> "SymbolPacket":
+        packet_id = new_id("packet")
+        packet = cls(
+            protocol_version=CAMBUS_PROTOCOL_VERSION,
+            packet_id=packet_id,
+            correlation_id=correlation_id or packet_id,
+            source_node=source_node,
+            destination_node=destination_node,
+            event=event,
+            qos=qos or QoSProfile(),
+        )
+        packet.validate()
+        return packet
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "SymbolPacket":
+        packet = cls(
+            protocol_version=str(value.get("protocol_version", "")),
+            packet_id=str(value.get("packet_id", "")),
+            correlation_id=str(value.get("correlation_id", "")),
+            source_node=str(value.get("source_node", "")),
+            destination_node=str(value.get("destination_node", "")),
+            event=MUEFEvent.from_dict(dict(value.get("event") or {})),
+            qos=QoSProfile(**dict(value.get("qos") or {})),
+        )
+        packet.validate()
+        return packet
+
+    def validate(self) -> None:
+        if self.protocol_version != CAMBUS_PROTOCOL_VERSION:
+            raise ValueError("Unsupported CAMbus protocol version")
+        if not self.packet_id or not self.correlation_id:
+            raise ValueError("CAMbus packet and correlation IDs are required")
+        if not self.source_node or not self.destination_node:
+            raise ValueError("CAMbus source and destination nodes are required")
+        self.event.validate()
+        self.qos.validate()
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        if self.qos.max_latency_ms is None:
+            value["qos"].pop("max_latency_ms")
+        return value
+
+
+def encode_packet(packet: SymbolPacket) -> bytes:
+    packet.validate()
+    payload = canonical_json_bytes(packet.to_dict())
+    if len(payload) > MAX_FRAME_BYTES:
+        raise ValueError("CAMbus frame exceeds maximum size")
+    return payload
+
+
+def decode_packet(payload: bytes) -> SymbolPacket:
+    if len(payload) > MAX_FRAME_BYTES:
+        raise ValueError("CAMbus frame exceeds maximum size")
+    return SymbolPacket.from_dict(json.loads(payload.decode("utf-8")))
+
+
+def send_frame(sock: socket.socket, packet: SymbolPacket) -> None:
+    payload = encode_packet(packet)
+    sock.sendall(struct.pack("!I", len(payload)) + payload)
+
+
+def receive_frame(sock: socket.socket) -> SymbolPacket:
+    header = _recv_exact(sock, 4)
+    length = struct.unpack("!I", header)[0]
+    if length > MAX_FRAME_BYTES:
+        raise ValueError("CAMbus frame exceeds maximum size")
+    return decode_packet(_recv_exact(sock, length))
+
+
+def send_tcp(address: tuple[str, int], packet: SymbolPacket, timeout: float = 5.0) -> None:
+    with socket.create_connection(address, timeout=timeout) as sock:
+        send_frame(sock, packet)
+
+
+def receive_one_tcp(listener: socket.socket, timeout: float = 5.0) -> SymbolPacket:
+    listener.settimeout(timeout)
+    conn, _ = listener.accept()
+    with conn:
+        conn.settimeout(timeout)
+        return receive_frame(conn)
+
+
+def _recv_exact(sock: socket.socket, length: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = length
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise ConnectionError("CAMbus connection closed before frame completed")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)

--- a/migi/events.py
+++ b/migi/events.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .models import SourceClass
+from .util import new_id, utc_now
+
+_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+
+
+@dataclass(frozen=True)
+class MUEFActor:
+    type: str
+    id: str
+
+
+@dataclass(frozen=True)
+class MUEFEvent:
+    schema_version: str
+    event_id: str
+    event_type: str
+    occurred_at: str
+    actor: MUEFActor
+    source_class: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    parent_event_id: str | None = None
+    receipt_id: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        event_type: str,
+        *,
+        actor_id: str,
+        actor_type: str = "service",
+        source_class: str = SourceClass.ORIGINAL.value,
+        payload: dict[str, Any] | None = None,
+    ) -> "MUEFEvent":
+        event = cls(
+            schema_version="muef.v0",
+            event_id=new_id("event"),
+            event_type=event_type,
+            occurred_at=utc_now(),
+            actor=MUEFActor(type=actor_type, id=actor_id),
+            source_class=source_class,
+            payload=dict(payload or {}),
+        )
+        event.validate()
+        return event
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "MUEFEvent":
+        actor = value.get("actor") or {}
+        event = cls(
+            schema_version=str(value.get("schema_version", "")),
+            event_id=str(value.get("event_id", "")),
+            event_type=str(value.get("event_type", "")),
+            occurred_at=str(value.get("occurred_at", "")),
+            actor=MUEFActor(type=str(actor.get("type", "")), id=str(actor.get("id", ""))),
+            source_class=str(value.get("source_class", "")),
+            payload=dict(value.get("payload") or {}),
+            parent_event_id=value.get("parent_event_id"),
+            receipt_id=value.get("receipt_id"),
+        )
+        event.validate()
+        return event
+
+    def validate(self) -> None:
+        if self.schema_version != "muef.v0":
+            raise ValueError("MUEF schema_version must be muef.v0")
+        if not self.event_id:
+            raise ValueError("MUEF event_id is required")
+        if not _EVENT_TYPE.fullmatch(self.event_type):
+            raise ValueError("MUEF event_type must be lowercase and namespaced")
+        if self.actor.type not in {"user", "agent", "service", "device", "organization"}:
+            raise ValueError("Unsupported MUEF actor type")
+        if not self.actor.id:
+            raise ValueError("MUEF actor id is required")
+        if self.source_class not in {item.value for item in SourceClass}:
+            raise ValueError("Unsupported MUEF source_class")
+        if not isinstance(self.payload, dict):
+            raise ValueError("MUEF payload must be an object")
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        if self.parent_event_id is None:
+            value.pop("parent_event_id")
+        if self.receipt_id is None:
+            value.pop("receipt_id")
+        return value

--- a/migi/genesis.py
+++ b/migi/genesis.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from .authority import LUFITGuard
+from .events import MUEFEvent
 from .models import (
     MIGIArtifact,
     MIGIExecution,
@@ -14,18 +15,22 @@ from .models import (
     MIGIReceipt,
     SourceClass,
 )
+from .replay import replay_verified_state
 from .storage import GenesisStore
 from .util import new_id, utc_now
 
 
 class GenesisNode:
-    """MIGI Genesis Node v0.1.
+    """MIGI Genesis Node.
 
-    Implements one accountable vertical slice:
+    Implements an accountable vertical slice:
     intent -> authority -> execution -> verification -> receipt -> memory -> recall.
+
+    v0.2 adds MUEF state events, deterministic replay, and a CAMbus-compatible
+    event boundary without making network receipt equivalent to authorization.
     """
 
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
 
     def __init__(self, db_path: str | Path, allowed_roots: Iterable[str | Path] | None = None):
         roots = list(allowed_roots or [Path.cwd()])
@@ -38,7 +43,13 @@ class GenesisNode:
             "service": "migi-genesis-node",
             "version": self.VERSION,
             "receipt_chain": verification,
-            "capabilities": ["artifact.inspect", "receipt.verify", "artifact.recall"],
+            "capabilities": [
+                "artifact.inspect",
+                "receipt.verify",
+                "artifact.recall",
+                "state.patch",
+                "state.replay",
+            ],
         }
 
     def inspect_artifact(
@@ -56,7 +67,7 @@ class GenesisNode:
             action="artifact.inspect",
             target_ref=str(target),
             consent_scope=consent_scope,
-            metadata={"requested_via": "genesis.v0.1"},
+            metadata={"requested_via": "genesis.v0.2"},
         )
         self.store.put("intent", intent.intent_id, intent.created_at, intent.to_dict())
 
@@ -148,6 +159,122 @@ class GenesisNode:
             "memory": memory.to_dict(),
         }
 
+    def process_muef_event(
+        self,
+        event: MUEFEvent,
+        *,
+        actor_id: str | None = None,
+        consent_scope: str = "local.state.write",
+        transport_ref: str | None = None,
+    ) -> dict[str, Any]:
+        """Process one MUEF state event through authority, receipt, and memory.
+
+        v0.2 intentionally supports only `migi.state.patch`. Receiving a CAMbus
+        packet does not authorize it; LUFITGuard evaluates the resulting intent.
+        """
+        event.validate()
+        if event.event_type != "migi.state.patch":
+            raise ValueError("Genesis v0.2 only executes migi.state.patch events")
+        patch = event.payload.get("state_patch")
+        if not isinstance(patch, dict):
+            raise ValueError("migi.state.patch requires an object payload.state_patch")
+
+        self.store.put("muef_event", event.event_id, event.occurred_at, event.to_dict())
+
+        intent = MIGIIntent(
+            intent_id=new_id("intent"),
+            created_at=utc_now(),
+            actor_id=actor_id or event.actor.id,
+            action="state.patch",
+            target_ref=f"state:{event.event_id}",
+            consent_scope=consent_scope,
+            metadata={
+                "requested_via": "cambus" if transport_ref else "genesis.local",
+                "muef_event_ref": event.event_id,
+                **({"transport_ref": transport_ref} if transport_ref else {}),
+            },
+        )
+        self.store.put("intent", intent.intent_id, intent.created_at, intent.to_dict())
+
+        decision = self.guard.evaluate(intent)
+        authority = decision.authority
+        self.store.put("authority", authority.authority_id, authority.decided_at, authority.to_dict())
+
+        if not decision.allowed:
+            return self._record_event_non_execution(event, intent, authority, transport_ref)
+
+        started_at = utc_now()
+        execution = MIGIExecution(
+            execution_id=new_id("exec"),
+            started_at=started_at,
+            completed_at=utc_now(),
+            intent_id=intent.intent_id,
+            authority_id=authority.authority_id,
+            executor="migi.genesis.state_patch",
+            operation="state.patch",
+            success=True,
+            output={
+                "event_id": event.event_id,
+                "applied_keys": sorted(str(key) for key in patch),
+                "deleted_keys": sorted(str(key) for key, value in patch.items() if value is None),
+            },
+            verification={
+                "event_valid": True,
+                "state_patch_object": True,
+                "authority_allowed": True,
+            },
+        )
+        self.store.put("execution", execution.execution_id, execution.completed_at, execution.to_dict())
+
+        receipt_metadata: dict[str, Any] = {
+            "execution_ref": execution.execution_id,
+            "executor": execution.executor,
+            "event_type": event.event_type,
+            "verified": True,
+        }
+        if transport_ref:
+            receipt_metadata["transport_ref"] = transport_ref
+
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=event.event_id,
+            source_class=SourceClass.EXECUTED.value,
+            output_ref=event.event_id,
+            metadata=receipt_metadata,
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=event.event_id,
+            receipt_id=receipt.receipt_id,
+            kind="migi.state.patch.completed",
+            summary=f"Applied verified state patch with {len(patch)} key(s).",
+            facts={
+                "event_ref": event.event_id,
+                "execution_ref": execution.execution_id,
+                "authority_ref": authority.authority_id,
+                "transport_ref": transport_ref,
+            },
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+
+        return {
+            "event": event.to_dict(),
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": execution.to_dict(),
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+            "replay": self.replay_state(),
+        }
+
+    def replay_state(self) -> dict[str, Any]:
+        return replay_verified_state(self.store).to_dict()
+
     def recall_artifact(self, reference: str) -> dict[str, Any] | None:
         artifact = self._find_artifact(reference)
         if artifact is None:
@@ -215,6 +342,45 @@ class GenesisNode:
             "receipt": receipt.to_dict(),
             "receipt_hash": receipt_hash,
             "memory": memory.to_dict(),
+        }
+
+    def _record_event_non_execution(self, event: MUEFEvent, intent: MIGIIntent, authority, transport_ref: str | None) -> dict[str, Any]:
+        metadata: dict[str, Any] = {"executed": False, "event_type": event.event_type}
+        if transport_ref:
+            metadata["transport_ref"] = transport_ref
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=event.event_id,
+            source_class=SourceClass.PROPOSED.value,
+            output_ref=event.event_id,
+            metadata=metadata,
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=event.event_id,
+            receipt_id=receipt.receipt_id,
+            kind="migi.state.patch.not_executed",
+            summary=f"State patch did not execute: {authority.reason_code}.",
+            facts={
+                "tre_logic": authority.tre_logic,
+                "reason_code": authority.reason_code,
+                "event_ref": event.event_id,
+                "transport_ref": transport_ref,
+            },
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+        return {
+            "event": event.to_dict(),
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": None,
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+            "replay": self.replay_state(),
         }
 
     def _make_receipt(

--- a/migi/replay.py
+++ b/migi/replay.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .canonical import canonical_json_bytes, sha256_hex
+from .events import MUEFEvent
+from .storage import GenesisStore
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    state: dict[str, Any] = field(default_factory=dict)
+    applied_events: int = 0
+    skipped_events: int = 0
+    chain_head: str = ""
+    state_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "applied_events": self.applied_events,
+            "skipped_events": self.skipped_events,
+            "chain_head": self.chain_head,
+            "state_hash": self.state_hash,
+        }
+
+
+def replay_verified_state(store: GenesisStore) -> ReplayResult:
+    verification = store.verify_chain()
+    if not verification.get("valid"):
+        raise ValueError(f"Cannot replay invalid receipt chain: {verification.get('reason')}")
+
+    receipts = {
+        receipt.get("output_ref"): receipt
+        for receipt in store.receipts()
+        if receipt.get("source_class") == "executed"
+        and receipt.get("authority", {}).get("tre_logic") == "+1"
+    }
+
+    state: dict[str, Any] = {}
+    applied = 0
+    skipped = 0
+
+    for raw_event in store.list_kind("muef_event"):
+        event = MUEFEvent.from_dict(raw_event)
+        receipt = receipts.get(event.event_id)
+        if receipt is None or event.event_type != "migi.state.patch":
+            skipped += 1
+            continue
+
+        patch = event.payload.get("state_patch")
+        if not isinstance(patch, dict):
+            skipped += 1
+            continue
+
+        for key in sorted(patch):
+            if not isinstance(key, str):
+                raise ValueError("State patch keys must be strings")
+            value = patch[key]
+            if value is None:
+                state.pop(key, None)
+            else:
+                state[key] = value
+        applied += 1
+
+    state_hash = sha256_hex(canonical_json_bytes(state))
+    return ReplayResult(
+        state=state,
+        applied_events=applied,
+        skipped_events=skipped,
+        chain_head=str(verification.get("head", "")),
+        state_hash=state_hash,
+    )

--- a/tests/test_cambus_replay.py
+++ b/tests/test_cambus_replay.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import socket
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from migi.cambus import SymbolPacket, receive_one_tcp, send_tcp
+from migi.events import MUEFEvent
+from migi.genesis import GenesisNode
+
+
+class CambusReplayTests(unittest.TestCase):
+    def test_authorized_state_patch_replays_deterministically(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+
+            first = MUEFEvent.create(
+                "migi.state.patch",
+                actor_id="tester",
+                payload={"state_patch": {"mode": "idle", "count": 1}},
+            )
+            second = MUEFEvent.create(
+                "migi.state.patch",
+                actor_id="tester",
+                payload={"state_patch": {"mode": "active", "count": 2}},
+            )
+
+            r1 = node.process_muef_event(first)
+            r2 = node.process_muef_event(second)
+
+            self.assertEqual(r1["authority"]["tre_logic"], "+1")
+            self.assertEqual(r2["authority"]["tre_logic"], "+1")
+            self.assertEqual(r2["replay"]["state"], {"count": 2, "mode": "active"})
+            self.assertEqual(r2["replay"]["applied_events"], 2)
+            self.assertTrue(r2["replay"]["state_hash"])
+            self.assertTrue(node.store.verify_chain()["valid"])
+
+    def test_hold_event_is_preserved_but_not_applied(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+            event = MUEFEvent.create(
+                "migi.state.patch",
+                actor_id="tester",
+                payload={"state_patch": {"mode": "blocked"}},
+            )
+
+            result = node.process_muef_event(event, consent_scope="unspecified")
+
+            self.assertEqual(result["authority"]["tre_logic"], "0")
+            self.assertIsNone(result["execution"])
+            self.assertEqual(result["replay"]["state"], {})
+            self.assertEqual(result["replay"]["applied_events"], 0)
+            self.assertEqual(result["replay"]["skipped_events"], 1)
+
+    def test_two_nodes_send_muef_over_cambus_then_replay(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            node_b = GenesisNode(root / "node-b.db", allowed_roots=[root])
+
+            listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            address = listener.getsockname()
+            result_box: dict[str, object] = {}
+
+            def receive_and_process() -> None:
+                packet = receive_one_tcp(listener)
+                result_box["result"] = node_b.process_muef_event(
+                    packet.event,
+                    transport_ref=packet.packet_id,
+                )
+
+            receiver = threading.Thread(target=receive_and_process)
+            receiver.start()
+
+            event = MUEFEvent.create(
+                "migi.state.patch",
+                actor_id="node-a",
+                actor_type="service",
+                payload={"state_patch": {"network_mode": "online"}},
+            )
+            packet = SymbolPacket.create(
+                source_node="node-a",
+                destination_node="node-b",
+                event=event,
+            )
+            send_tcp((address[0], address[1]), packet)
+            receiver.join(timeout=5)
+            listener.close()
+
+            self.assertFalse(receiver.is_alive())
+            result = result_box["result"]
+            self.assertEqual(result["authority"]["tre_logic"], "+1")
+            self.assertEqual(result["replay"]["state"]["network_mode"], "online")
+            self.assertEqual(result["receipt"]["metadata"]["transport_ref"], packet.packet_id)
+            self.assertTrue(node_b.store.verify_chain()["valid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extend the merged Genesis Node v0.1 with the next whitespace-critical slice: MUEF state events, scoped authority, CAMbus transport, and deterministic replay.

## What this adds

- executable `MUEFEvent` / `MUEFActor` model aligned with `muef.v0`
- `state.patch` as the first explicitly authorized state-transition operation
- LUFITGuard policy for `local.state.write` / `private.local.state.write`
- transport-neutral CAMbus `SymbolPacket` with QoS metadata
- canonical JSON + 4-byte length-prefixed framing
- first TCP adapter for two-node testing
- receipt-linked MUEF event execution
- deterministic replay from verified `executed` + Tre Logic `+1` event lineage
- replay state hash for cross-implementation comparison
- preserved-but-not-applied behavior for held/denied events
- two-node localhost integration test

## Core invariant

`network receipt != authorization`

Receiving a CAMbus packet only delivers a MUEF event. The receiving Genesis node creates an intent and still requires LUFITGuard/Tre Logic authorization before the event can alter replayed state.

## Executable path

```text
Node A
 -> CAMbus SymbolPacket
 -> Node B
 -> MUEF validation
 -> MIGIIntent(state.patch)
 -> LUFITGuard
 -> execution or non-execution
 -> MIGIReceipt
 -> existing Genesis receipt chain
 -> deterministic replay
```

## Scope

v0.2 intentionally supports only `migi.state.patch`. It does not add generic remote command execution, CAN hardware, LiFi, or arbitrary tool invocation.

## Tests

The new tests cover:
- deterministic multi-event replay
- held event preservation without state mutation
- two-node CAMbus TCP delivery -> authority -> receipt -> replay

The existing quality gate uses unittest discovery, so these tests run without requiring a workflow behavior change.

## Follow-up

After this lands:
1. salvage the non-duplicative polyglot RAG0SHOT code-memory work from PR #7 onto the Genesis mainline
2. add exact receipt/event/hash recall
3. add CAMbus adapter interface for CAN/WebSocket/optical transports
4. add idempotency/replay protection and node identity/authentication
