### PR TITLE
feat: expose RAG0SHOT code recall through Genesis interfaces

### DIFF
--- a/migi/api.py
+++ b/migi/api.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from .code_memory import CodeMemory, CodeSource
 from .genesis import GenesisNode
 
 
@@ -16,27 +17,44 @@ class ExecuteRequest(BaseModel):
     consent_scope: str = "local.read"
 
 
+class CodeImportRequest(BaseModel):
+    text: str
+    source_kind: str = "chat"
+    source_uri: str
+    status: str = "prototype"
+    named_systems: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    path: str | None = None
+    revision: str | None = None
+    conversation_id: str | None = None
+    message_id: str | None = None
+
+
 DB_PATH = os.environ.get("MIGI_DB_PATH", ".migi/genesis.db")
 ALLOWED_ROOT = Path(os.environ.get("MIGI_ALLOWED_ROOT", Path.cwd())).expanduser().resolve()
 node = GenesisNode(DB_PATH, allowed_roots=[ALLOWED_ROOT])
+code_memory = CodeMemory(node.store)
 app = FastAPI(title="MIGI Genesis Node", version=node.VERSION)
 
 
 @app.get("/status")
 def status():
-    return node.status()
+    value = node.status()
+    capabilities = list(value.get("capabilities", []))
+    capabilities.extend(["code.import", "code.recall", "code.find"])
+    value["capabilities"] = sorted(set(capabilities))
+    return value
 
 
 @app.post("/execute")
 def execute(request: ExecuteRequest):
     if request.action != "artifact.inspect":
-        raise HTTPException(status_code=400, detail="Genesis v0.1 only supports artifact.inspect")
-    result = node.inspect_artifact(
+        raise HTTPException(status_code=400, detail="This endpoint currently supports artifact.inspect only")
+    return node.inspect_artifact(
         request.target,
         actor_id=request.actor_id,
         consent_scope=request.consent_scope,
     )
-    return result
 
 
 @app.get("/receipts")
@@ -49,4 +67,55 @@ def recall(reference: str):
     result = node.recall_artifact(reference)
     if result is None:
         raise HTTPException(status_code=404, detail="Artifact not found")
+    return result
+
+
+@app.post("/code/import")
+def import_code(request: CodeImportRequest):
+    source = CodeSource(
+        kind=request.source_kind,
+        uri=request.source_uri,
+        path=request.path,
+        revision=request.revision,
+        conversation_id=request.conversation_id,
+        message_id=request.message_id,
+    )
+    try:
+        artifacts = code_memory.import_fenced_text(
+            request.text,
+            source=source,
+            status=request.status,
+            named_systems=request.named_systems,
+            tags=request.tags,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return {"count": len(artifacts), "artifacts": artifacts}
+
+
+@app.get("/code/recall")
+def recall_code(
+    q: str = Query(..., min_length=1),
+    language: list[str] = Query(default=[]),
+    system: list[str] = Query(default=[]),
+    source_kind: list[str] = Query(default=[]),
+    limit: int = Query(default=8, ge=1, le=100),
+):
+    return {
+        "query": q,
+        "hits": code_memory.recall(
+            q,
+            languages=language,
+            named_systems=system,
+            source_kinds=source_kind,
+            limit=limit,
+        ),
+    }
+
+
+@app.get("/code/find/{reference}")
+def find_code(reference: str):
+    result = code_memory.find_exact(reference)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Code artifact not found")
     return result

--- a/migi/cli.py
+++ b/migi/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from .code_memory import CodeMemory, CodeSource
 from .genesis import GenesisNode
 
 
@@ -24,6 +25,27 @@ def main() -> int:
     recall_cmd = sub.add_parser("recall", help="Reconstruct artifact history from receipts")
     recall_cmd.add_argument("reference", help="Artifact ID, SHA-256, path, or filename")
 
+    code_import = sub.add_parser("code-import", help="Import fenced code from a chat/log/Markdown file")
+    code_import.add_argument("path")
+    code_import.add_argument("--source-kind", default="file", choices=["chat", "log", "repository", "file", "generated", "external"])
+    code_import.add_argument("--source-uri")
+    code_import.add_argument("--status", default="prototype", choices=["concept", "specification", "prototype", "executable", "tested", "deprecated"])
+    code_import.add_argument("--system", action="append", default=[])
+    code_import.add_argument("--tag", action="append", default=[])
+    code_import.add_argument("--revision")
+    code_import.add_argument("--conversation-id")
+    code_import.add_argument("--message-id")
+
+    code_recall = sub.add_parser("code-recall", help="Search RAG0SHOT code memory")
+    code_recall.add_argument("query")
+    code_recall.add_argument("--language", action="append", default=[])
+    code_recall.add_argument("--system", action="append", default=[])
+    code_recall.add_argument("--source-kind", action="append", default=[])
+    code_recall.add_argument("--limit", type=int, default=8)
+
+    code_find = sub.add_parser("code-find", help="Find a code artifact by ID or exact SHA-256 content hash")
+    code_find.add_argument("reference")
+
     sub.add_parser("verify", help="Verify the receipt hash chain")
     sub.add_parser("status", help="Show Genesis Node status")
 
@@ -37,8 +59,44 @@ def main() -> int:
         return 0 if result["authority"]["tre_logic"] == "+1" else 2
 
     node = GenesisNode(args.db, allowed_roots=[Path.cwd()])
+    code_memory = CodeMemory(node.store)
+
     if args.command == "recall":
         result = node.recall_artifact(args.reference)
+        _print(result)
+        return 0 if result is not None else 1
+    if args.command == "code-import":
+        path = Path(args.path).expanduser().resolve()
+        text = path.read_text(encoding="utf-8")
+        source = CodeSource(
+            kind=args.source_kind,
+            uri=args.source_uri or f"file:{path}",
+            path=str(path),
+            revision=args.revision,
+            conversation_id=args.conversation_id,
+            message_id=args.message_id,
+        )
+        artifacts = code_memory.import_fenced_text(
+            text,
+            source=source,
+            status=args.status,
+            named_systems=args.system,
+            tags=args.tag,
+        )
+        _print({"count": len(artifacts), "artifacts": artifacts})
+        return 0
+    if args.command == "code-recall":
+        hits = code_memory.recall(
+            args.query,
+            languages=args.language,
+            named_systems=args.system,
+            source_kinds=args.source_kind,
+            limit=max(1, args.limit),
+        )
+        _print({"query": args.query, "hits": hits})
+        return 0 if hits else 1
+    if args.command == "code-find":
+        result = code_memory.find_exact(args.reference)
         _print(result)
         return 0 if result is not None else 1
     if args.command == "verify":
@@ -46,7 +104,9 @@ def main() -> int:
         _print(result)
         return 0 if result["valid"] else 1
     if args.command == "status":
-        _print(node.status())
+        result = node.status()
+        result["capabilities"] = sorted(set(result.get("capabilities", [])) | {"code.import", "code.recall", "code.find"})
+        _print(result)
         return 0
     return 1
 

--- a/tests/test_code_memory_cli.py
+++ b/tests/test_code_memory_cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from migi.cli import main
+
+
+class CodeMemoryCliTests(unittest.TestCase):
+    def _run(self, argv: list[str]) -> tuple[int, object]:
+        output = io.StringIO()
+        with patch("sys.argv", ["migi-genesis", *argv]), redirect_stdout(output):
+            code = main()
+        text = output.getvalue().strip()
+        return code, json.loads(text) if text else None
+
+    def test_import_recall_and_exact_find_across_cli_process_calls(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db = root / "genesis.db"
+            history = root / "conversation.md"
+            history.write_text(
+                """Discussion\n\n```python\ndef rag0shot_recall(query):\n    return query\n```\n""",
+                encoding="utf-8",
+            )
+
+            code, imported = self._run(
+                [
+                    "--db",
+                    str(db),
+                    "code-import",
+                    str(history),
+                    "--source-kind",
+                    "chat",
+                    "--source-uri",
+                    "chat:conversation-1",
+                    "--conversation-id",
+                    "conversation-1",
+                    "--system",
+                    "RAG0SHOT",
+                ]
+            )
+            self.assertEqual(code, 0)
+            self.assertEqual(imported["count"], 1)
+            artifact = imported["artifacts"][0]
+            self.assertEqual(artifact["language"], "python")
+
+            code, recalled = self._run(
+                [
+                    "--db",
+                    str(db),
+                    "code-recall",
+                    "rag0shot recall",
+                    "--language",
+                    "python",
+                ]
+            )
+            self.assertEqual(code, 0)
+            self.assertEqual(len(recalled["hits"]), 1)
+            self.assertEqual(recalled["hits"][0]["artifact_id"], artifact["artifact_id"])
+            self.assertEqual(recalled["hits"][0]["source"]["kind"], "chat")
+
+            code, found = self._run(
+                ["--db", str(db), "code-find", artifact["content_hash"]]
+            )
+            self.assertEqual(code, 0)
+            self.assertEqual(found["artifact_id"], artifact["artifact_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make the merged RAG0SHOT polyglot code-memory layer usable through the existing Genesis API and CLI.

## API
Adds:
- `POST /code/import` — ingest fenced code with source provenance
- `GET /code/recall` — lexical/metadata recall with language/system/source filters
- `GET /code/find/{reference}` — exact artifact ID or SHA-256 lookup

The API status surface now advertises `code.import`, `code.recall`, and `code.find`.

## CLI
Adds:
- `code-import <file>`
- `code-recall <query>`
- `code-find <artifact-id-or-hash>`

Import options preserve source kind/URI, revision, conversation/message IDs, named systems, tags, and code status.

## Boundary

Recall remains non-executing. These interfaces only import/search/find code artifacts; they do not route recalled content to a runtime.

## Acceptance test

A real CLI persistence test:
1. imports a fenced Python snippet from a Markdown conversation file
2. stores it in the Genesis SQLite database
3. recalls it in a separate CLI call using language filtering
4. resolves it exactly by SHA-256 content hash
5. verifies chat provenance survives the round trip
