### PR TITLE
MIGI-CS-002: LUFIT + SFO verifiable claim core

### DIFF
--- a/docs/architecture/lufit-sfo-verifiable-core.md
+++ b/docs/architecture/lufit-sfo-verifiable-core.md
@@ -1,0 +1,154 @@
+# MIGI-CS-002 — LUFIT + SFO Verifiable Claim Core
+
+MIGI-CS-002 turns the LUFIT/SFO theory into executable computer-science rules on top of the current Python Genesis Node.
+
+## Core contract
+
+```text
+State → Flow → Observation
+                  ↓
+              Evidence
+                  ↓
+         Tre evidence state
+                  ↓
+          LUFIT profile check
+                  ↓
+          Qualified claim
+                  ↓
+        Derived MIGIReceipt
+                  ↓
+              Memory
+                  ↓
+               Recall
+```
+
+The runtime composes with the existing `GenesisStore` and `LUFITGuard`; it does not create a second database or authority system.
+
+## SFO
+
+An SFO record contains:
+
+- `state_before`
+- `state_after`
+- an explicit observation
+
+The observation preserves its source class (`observed`, `derived`, `simulated`, etc.), confidence, source identifier, and optional provenance reference.
+
+## Evidence / Tre state
+
+Each evidence item uses:
+
+```text
+direction ∈ [-1, 1]
+confidence ∈ [0, 1]
+reliability ∈ [0, 1]
+provenance_quality ∈ [0, 1]
+```
+
+Weight:
+
+```text
+w = confidence × reliability × provenance_quality
+```
+
+Weighted mass is normalized into:
+
+```text
+[contradicted, unresolved, supported]
+```
+
+Net support:
+
+```text
+support_score = P(supported) - P(contradicted)
+```
+
+The default threshold is `0.60`, mapped to the three-value evidence state:
+
+```text
++1 supported
+ 0 unresolved
+-1 contradicted
+```
+
+Uncertainty is normalized Shannon entropy over the three-way distribution.
+
+## LUFIT executable profile
+
+The v0 profile is:
+
+```text
+π = (resolution_level, budget_units, observables, methods, cutoff)
+```
+
+A claim becomes `out_of_profile` when its requirements exceed any declared bound.
+
+This makes `OUT_OF_PROFILE` a first-class result rather than forcing the system to invent an answer.
+
+## Simulation boundary
+
+A source classified as `simulated` can never silently become a factual `supported` observation through this runtime.
+
+Even if the simulated result has strong evidence weights, its factual qualification is:
+
+```text
+simulation_only
+```
+
+A later real observation can be compared against that prediction in a separate SFO cycle.
+
+## Authority boundary
+
+Claim qualification uses a distinct action and consent scope:
+
+```text
+action: claim.qualify
+scope:  local.reason | private.local.reason
+```
+
+No reasoning execution occurs when the scope is absent. A blocked attempt receives a `proposed` receipt and no execution record.
+
+This preserves the architecture rule:
+
+```text
+Inference != Authority
+```
+
+## RAG0SHOT scoring baseline
+
+MIGI-CS-002 defines an evidence-aware retrieval score:
+
+```text
+score =
+    0.40 × semantic
+  + 0.20 × provenance
+  + 0.15 × reliability
+  + 0.15 × graph
+  + 0.10 × temporal
+```
+
+The weights are a benchmarkable starting point, not an assertion that they are optimal.
+
+## Current tests
+
+The automated suite proves:
+
+1. no evidence returns unresolved;
+2. a supported observed claim produces a derived receipt and can be recalled;
+3. simulation remains `simulation_only`;
+4. an out-of-profile claim is explicitly labeled;
+5. missing reasoning authority produces Hold (`0`) and no execution;
+6. provenance-aware RAG0SHOT ranking can prefer a trustworthy result over a superficially more similar result.
+
+## Next benchmark
+
+The next milestone should generate a fixed synthetic corpus (target: 1,000 claims) and compare:
+
+- semantic-only retrieval vs evidence-aware RAG0SHOT;
+- precision / recall / MRR;
+- Brier score and calibration error;
+- bad-source retrieval rate;
+- out-of-profile refusal accuracy;
+- latency and receipt overhead.
+
+MCFP / FieldWord64 and Hex64³ should follow after this epistemic core is benchmarked, so compression gains do not mask correctness problems.

--- a/docs/architecture/lufit-sfo-verifiable-core.md
+++ b/docs/architecture/lufit-sfo-verifiable-core.md
@@ -57,6 +57,20 @@ Weighted mass is normalized into:
 [contradicted, unresolved, supported]
 ```
 
+Directional normalization alone would allow an arbitrarily weak source to look
+perfectly supportive or contradictory. The runtime therefore preserves absolute
+evidence strength. One unit of total weight is the default full-strength reference:
+
+```text
+strength = min(total_evidence_weight / reference_weight, 1)
+P(final) = strength × P(directional) + (1 - strength) × [1/3, 1/3, 1/3]
+```
+
+Sub-reference evidence is blended toward uniform ignorance. A source with near-zero
+confidence therefore remains unresolved instead of becoming factual support merely
+because no competing evidence was supplied. Both `evidence_weight` and
+`evidence_strength` are included in the assessment for audit and calibration.
+
 Net support:
 
 ```text
@@ -94,6 +108,15 @@ Even if the simulated result has strong evidence weights, its factual qualificat
 ```text
 simulation_only
 ```
+
+This classification takes precedence over profile rejection. Profile violations are
+still retained separately, so a simulated, out-of-profile result is represented as
+`simulation_only` with an `out_of_profile` profile status. Its derived receipt is not
+marked as factually verified.
+
+`execution.success` means the qualification operation completed. Receipt metadata
+`verified` and execution verification `factual_claim_verified` are true only when an
+in-profile, non-simulated factual claim is supported.
 
 A later real observation can be compared against that prediction in a separate SFO cycle.
 
@@ -134,11 +157,13 @@ The weights are a benchmarkable starting point, not an assertion that they are o
 The automated suite proves:
 
 1. no evidence returns unresolved;
-2. a supported observed claim produces a derived receipt and can be recalled;
-3. simulation remains `simulation_only`;
-4. an out-of-profile claim is explicitly labeled;
-5. missing reasoning authority produces Hold (`0`) and no execution;
-6. provenance-aware RAG0SHOT ranking can prefer a trustworthy result over a superficially more similar result.
+2. arbitrarily weak evidence remains unresolved;
+3. a supported observed claim produces a factually verified derived receipt and can be recalled;
+4. simulation remains `simulation_only`, including when it is out of profile;
+5. simulation-only and out-of-profile receipts are not marked as factually verified;
+6. an out-of-profile claim is explicitly labeled;
+7. missing reasoning authority produces Hold (`0`) and no execution;
+8. provenance-aware RAG0SHOT ranking can prefer a trustworthy result over a superficially more similar result.
 
 ## Next benchmark
 

--- a/migi/authority.py
+++ b/migi/authority.py
@@ -20,15 +20,16 @@ class AuthorityDecision:
 class LUFITGuard:
     """Minimal Genesis policy gate.
 
-    v0.2 keeps the original read-only artifact inspection policy and adds one
-    tightly scoped state transition: `state.patch` with explicit local write
-    consent and a synthetic `state:` target. Network transport never grants
-    authority by itself.
+    v0.3 keeps artifact inspection and state-patch authority separate from
+    epistemic claim qualification. Claim reasoning requires its own explicit
+    local reasoning scope; network transport or a valid receipt never grants
+    write or reasoning authority by itself.
     """
 
-    ALLOWED_ACTIONS = {"artifact.inspect", "state.patch"}
+    ALLOWED_ACTIONS = {"artifact.inspect", "state.patch", "claim.qualify"}
     ARTIFACT_SCOPES = {"local.read", "private.local.read"}
     STATE_SCOPES = {"local.state.write", "private.local.state.write"}
+    CLAIM_SCOPES = {"local.reason", "private.local.reason"}
 
     def __init__(self, allowed_roots: Iterable[Path]):
         roots = [Path(root).expanduser().resolve() for root in allowed_roots]
@@ -44,6 +45,8 @@ class LUFITGuard:
             return self._evaluate_artifact_inspect(intent)
         if intent.action == "state.patch":
             return self._evaluate_state_patch(intent)
+        if intent.action == "claim.qualify":
+            return self._evaluate_claim_qualify(intent)
 
         return self._decision(intent, TreLogic.DENY, "policy.action_not_allowlisted")
 
@@ -64,6 +67,13 @@ class LUFITGuard:
         if not intent.target_ref.startswith("state:"):
             return self._decision(intent, TreLogic.DENY, "policy.invalid_state_target")
         return self._decision(intent, TreLogic.ALLOW, "authority.explicit_local_state_write")
+
+    def _evaluate_claim_qualify(self, intent: MIGIIntent) -> AuthorityDecision:
+        if intent.consent_scope not in self.CLAIM_SCOPES:
+            return self._decision(intent, TreLogic.HOLD, "authority.explicit_reasoning_required")
+        if not intent.target_ref.startswith("claim:"):
+            return self._decision(intent, TreLogic.DENY, "policy.invalid_claim_target")
+        return self._decision(intent, TreLogic.ALLOW, "authority.explicit_local_reasoning")
 
     def _decision(self, intent: MIGIIntent, state: TreLogic, reason: str) -> AuthorityDecision:
         authority = MIGIAuthority(

--- a/migi/claim_runtime.py
+++ b/migi/claim_runtime.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .authority import LUFITGuard
+from .epistemics import (
+    ClaimRequirements,
+    EvidenceItem,
+    LUFITProfile,
+    SFOObservation,
+    SFORecord,
+    evaluate_evidence,
+    qualify_factual_claim,
+    validate_profile,
+)
+from .models import MIGIExecution, MIGIIntent, MIGIMemory, MIGIReceipt, SourceClass, TreLogic
+from .storage import GenesisStore
+from .util import new_id, utc_now
+
+
+class VerifiableClaimRuntime:
+    """MIGI-CS-002 vertical slice for evidence-bounded claim qualification.
+
+    This runtime composes with the existing GenesisStore and LUFITGuard. It does
+    not perform physical/world-changing actions. It records a reasoning intent,
+    evaluates evidence and the LUFIT profile, preserves SFO state/observation
+    boundaries, issues a derived receipt, and writes a recallable memory.
+    """
+
+    VERSION = "0.1.0"
+
+    def __init__(self, store: GenesisStore, guard: LUFITGuard):
+        self.store = store
+        self.guard = guard
+
+    def qualify_claim(
+        self,
+        claim_ref: str,
+        *,
+        state_before: Any,
+        state_after: Any,
+        observation: SFOObservation,
+        evidence: Iterable[EvidenceItem],
+        profile: LUFITProfile,
+        requirements: ClaimRequirements,
+        actor_id: str = "local-user",
+        consent_scope: str = "local.reason",
+        threshold: float = 0.60,
+    ) -> dict[str, Any]:
+        if not claim_ref.strip():
+            raise ValueError("claim_ref is required")
+        observation.validate()
+
+        intent = MIGIIntent(
+            intent_id=new_id("intent"),
+            created_at=utc_now(),
+            actor_id=actor_id,
+            action="claim.qualify",
+            target_ref=f"claim:{claim_ref}",
+            consent_scope=consent_scope,
+            metadata={"requested_via": "migi-cs-002", "claim_ref": claim_ref},
+        )
+        self.store.put("intent", intent.intent_id, intent.created_at, intent.to_dict())
+
+        decision = self.guard.evaluate(intent)
+        authority = decision.authority
+        self.store.put("authority", authority.authority_id, authority.decided_at, authority.to_dict())
+        if not decision.allowed:
+            return self._record_non_execution(claim_ref, intent, authority)
+
+        assessment = evaluate_evidence(evidence, threshold=threshold)
+        profile_status = validate_profile(profile, requirements)
+        qualification = qualify_factual_claim(
+            source_class=observation.source_class,
+            profile_status=profile_status,
+            assessment=assessment,
+        )
+        sfo = SFORecord(
+            state_before=state_before,
+            state_after=state_after,
+            observation=observation,
+        )
+
+        started_at = utc_now()
+        output = {
+            "claim_ref": claim_ref,
+            "qualification": qualification,
+            "assessment": assessment.to_dict(),
+            "profile": profile_status.to_dict(),
+            "sfo": sfo.to_dict(),
+        }
+        execution = MIGIExecution(
+            execution_id=new_id("exec"),
+            started_at=started_at,
+            completed_at=utc_now(),
+            intent_id=intent.intent_id,
+            authority_id=authority.authority_id,
+            executor="migi.claim_runtime.qualify_claim",
+            operation="claim.qualify",
+            success=True,
+            output=output,
+            verification={
+                "authority_allowed": True,
+                "evidence_evaluated": True,
+                "profile_checked": True,
+                "simulation_preserved": (
+                    observation.source_class != SourceClass.SIMULATED.value
+                    or qualification == "simulation_only"
+                ),
+            },
+        )
+        self.store.put("execution", execution.execution_id, execution.completed_at, execution.to_dict())
+
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=execution.execution_id,
+            source_class=SourceClass.DERIVED.value,
+            output_ref=f"claim:{claim_ref}",
+            metadata={
+                "execution_ref": execution.execution_id,
+                "qualification": qualification,
+                "observation_source_class": observation.source_class,
+                "profile_status": profile_status.to_dict()["status"],
+                "verified": True,
+            },
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=f"claim:{claim_ref}",
+            receipt_id=receipt.receipt_id,
+            kind="migi.claim.qualified",
+            summary=(
+                f"Claim {claim_ref} qualified as {qualification}; "
+                f"Tre evidence state {assessment.state}; "
+                f"LUFIT {profile_status.to_dict()['status']}."
+            ),
+            facts={
+                "claim_ref": claim_ref,
+                "qualification": qualification,
+                "tre_evidence_state": assessment.state,
+                "support_score": assessment.support_score,
+                "confidence": assessment.confidence,
+                "uncertainty": assessment.uncertainty,
+                "profile_status": profile_status.to_dict()["status"],
+                "execution_ref": execution.execution_id,
+                "authority_ref": authority.authority_id,
+            },
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+
+        return {
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": execution.to_dict(),
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+            "chain": self.store.verify_chain(),
+        }
+
+    def recall_claim(self, claim_ref: str) -> dict[str, Any] | None:
+        subject_ref = f"claim:{claim_ref}"
+        memories = [m for m in self.store.list_kind("memory") if m.get("subject_ref") == subject_ref]
+        receipts = [r for r in self.store.receipts() if r.get("output_ref") == subject_ref]
+        if not memories and not receipts:
+            return None
+
+        history: list[dict[str, Any]] = []
+        for receipt in receipts:
+            intent = self.store.get(receipt["intent_ref"])
+            execution_ref = receipt.get("metadata", {}).get("execution_ref")
+            execution = self.store.get(execution_ref) if execution_ref else None
+            history.append({"receipt": receipt, "intent": intent, "execution": execution})
+
+        return {
+            "claim_ref": claim_ref,
+            "history": history,
+            "memories": memories,
+            "chain": self.store.verify_chain(),
+        }
+
+    def _record_non_execution(self, claim_ref: str, intent: MIGIIntent, authority) -> dict[str, Any]:
+        receipt = self._make_receipt(
+            intent=intent,
+            authority=authority,
+            event_id=authority.authority_id,
+            source_class=SourceClass.PROPOSED.value,
+            output_ref=f"claim:{claim_ref}",
+            metadata={"executed": False, "qualification": "not_evaluated"},
+        )
+        receipt_hash = self.store.append_receipt(receipt)
+        memory = MIGIMemory(
+            memory_id=new_id("memory"),
+            created_at=utc_now(),
+            subject_ref=f"claim:{claim_ref}",
+            receipt_id=receipt.receipt_id,
+            kind="migi.claim.not_executed",
+            summary=f"Claim qualification did not execute: {authority.reason_code}.",
+            facts={"tre_logic": authority.tre_logic, "reason_code": authority.reason_code},
+        )
+        self.store.put("memory", memory.memory_id, memory.created_at, memory.to_dict())
+        return {
+            "intent": intent.to_dict(),
+            "authority": authority.to_dict(),
+            "execution": None,
+            "receipt": receipt.to_dict(),
+            "receipt_hash": receipt_hash,
+            "memory": memory.to_dict(),
+            "chain": self.store.verify_chain(),
+        }
+
+    def _make_receipt(
+        self,
+        *,
+        intent: MIGIIntent,
+        authority,
+        event_id: str,
+        source_class: str,
+        output_ref: str,
+        metadata: dict[str, Any],
+    ) -> MIGIReceipt:
+        if source_class == SourceClass.EXECUTED.value and authority.tre_logic != TreLogic.ALLOW.value:
+            raise ValueError("executed receipt requires Tre Logic +1 authority")
+        return MIGIReceipt(
+            schema_version="migi-receipt.v0",
+            receipt_id=new_id("receipt"),
+            issued_at=utc_now(),
+            event_id=event_id,
+            source_class=source_class,
+            intent_ref=intent.intent_id,
+            output_ref=output_ref,
+            previous_receipt_ref=self.store.latest_receipt_hash(),
+            authority={
+                "tre_logic": authority.tre_logic,
+                "reason_code": authority.reason_code,
+                "consent_scope": authority.consent_scope,
+            },
+            metadata=metadata,
+        )

--- a/migi/claim_runtime.py
+++ b/migi/claim_runtime.py
@@ -75,6 +75,7 @@ class VerifiableClaimRuntime:
             profile_status=profile_status,
             assessment=assessment,
         )
+        factual_claim_verified = qualification == "supported"
         sfo = SFORecord(
             state_before=state_before,
             state_after=state_after,
@@ -107,6 +108,7 @@ class VerifiableClaimRuntime:
                     observation.source_class != SourceClass.SIMULATED.value
                     or qualification == "simulation_only"
                 ),
+                "factual_claim_verified": factual_claim_verified,
             },
         )
         self.store.put("execution", execution.execution_id, execution.completed_at, execution.to_dict())
@@ -122,7 +124,8 @@ class VerifiableClaimRuntime:
                 "qualification": qualification,
                 "observation_source_class": observation.source_class,
                 "profile_status": profile_status.to_dict()["status"],
-                "verified": True,
+                "evaluation_completed": True,
+                "verified": factual_claim_verified,
             },
         )
         receipt_hash = self.store.append_receipt(receipt)
@@ -146,6 +149,7 @@ class VerifiableClaimRuntime:
                 "confidence": assessment.confidence,
                 "uncertainty": assessment.uncertainty,
                 "profile_status": profile_status.to_dict()["status"],
+                "factual_claim_verified": factual_claim_verified,
                 "execution_ref": execution.execution_id,
                 "authority_ref": authority.authority_id,
             },

--- a/migi/epistemics.py
+++ b/migi/epistemics.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Iterable
+
+from .models import SourceClass
+
+
+class EvidenceState(str, Enum):
+    SUPPORTED = "+1"
+    UNRESOLVED = "0"
+    CONTRADICTED = "-1"
+
+
+class ClaimQualification(str, Enum):
+    SUPPORTED = "supported"
+    UNRESOLVED = "unresolved"
+    CONTRADICTED = "contradicted"
+    OUT_OF_PROFILE = "out_of_profile"
+    SIMULATION_ONLY = "simulation_only"
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """One bounded piece of evidence.
+
+    direction is in [-1, 1]: -1 contradicts, 0 is neutral/unknown, +1 supports.
+    confidence, reliability, and provenance_quality are in [0, 1].
+    """
+
+    direction: float
+    confidence: float
+    reliability: float
+    provenance_quality: float
+
+    def validate(self) -> None:
+        if not math.isfinite(self.direction) or not -1.0 <= self.direction <= 1.0:
+            raise ValueError("evidence direction must be finite and in [-1, 1]")
+        for name, value in (
+            ("confidence", self.confidence),
+            ("reliability", self.reliability),
+            ("provenance_quality", self.provenance_quality),
+        ):
+            if not _unit_interval(value):
+                raise ValueError(f"evidence {name} must be finite and in [0, 1]")
+
+
+@dataclass(frozen=True)
+class EvidenceAssessment:
+    state: str
+    support_score: float
+    confidence: float
+    uncertainty: float
+    probabilities: tuple[float, float, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "support_score": self.support_score,
+            "confidence": self.confidence,
+            "uncertainty": self.uncertainty,
+            "probabilities": {
+                "contradicted": self.probabilities[0],
+                "unresolved": self.probabilities[1],
+                "supported": self.probabilities[2],
+            },
+        }
+
+
+@dataclass(frozen=True)
+class SFOObservation:
+    source_id: str
+    source_class: str
+    value: Any
+    confidence: float
+    provenance_ref: str | None = None
+
+    def validate(self) -> None:
+        if not self.source_id:
+            raise ValueError("SFO observation source_id is required")
+        valid_classes = {value.value for value in SourceClass}
+        if self.source_class not in valid_classes:
+            raise ValueError(f"unsupported SFO source_class: {self.source_class}")
+        if not _unit_interval(self.confidence):
+            raise ValueError("SFO observation confidence must be finite and in [0, 1]")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+@dataclass(frozen=True)
+class SFORecord:
+    state_before: Any
+    state_after: Any
+    observation: SFOObservation
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state_before": self.state_before,
+            "state_after": self.state_after,
+            "observation": self.observation.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class LUFITProfile:
+    """Executable v0 LUFIT validity profile.
+
+    Higher resolution_level means a finer/more capable declared resolution.
+    cutoff is the absolute regime boundary for the profile.
+    """
+
+    resolution_level: float
+    budget_units: int
+    observables: frozenset[str]
+    methods: frozenset[str]
+    cutoff: float
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        resolution_level: float,
+        budget_units: int,
+        observables: Iterable[str],
+        methods: Iterable[str],
+        cutoff: float,
+    ) -> "LUFITProfile":
+        return cls(
+            resolution_level=resolution_level,
+            budget_units=budget_units,
+            observables=frozenset(observables),
+            methods=frozenset(methods),
+            cutoff=cutoff,
+        )
+
+
+@dataclass(frozen=True)
+class ClaimRequirements:
+    required_resolution_level: float
+    estimated_cost_units: int
+    required_observables: frozenset[str]
+    method: str
+    regime_value: float
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        required_resolution_level: float,
+        estimated_cost_units: int,
+        required_observables: Iterable[str],
+        method: str,
+        regime_value: float,
+    ) -> "ClaimRequirements":
+        return cls(
+            required_resolution_level=required_resolution_level,
+            estimated_cost_units=estimated_cost_units,
+            required_observables=frozenset(required_observables),
+            method=method,
+            regime_value=regime_value,
+        )
+
+
+@dataclass(frozen=True)
+class ProfileStatus:
+    in_profile: bool
+    violations: tuple[dict[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": "in_profile" if self.in_profile else "out_of_profile",
+            "violations": list(self.violations),
+        }
+
+
+@dataclass(frozen=True)
+class RetrievalSignals:
+    semantic: float
+    provenance: float
+    reliability: float
+    graph: float
+    temporal: float
+
+    def validate(self) -> None:
+        for name, value in asdict(self).items():
+            if not _unit_interval(float(value)):
+                raise ValueError(f"retrieval signal {name} must be finite and in [0, 1]")
+
+
+def evaluate_evidence(evidence: Iterable[EvidenceItem], *, threshold: float = 0.60) -> EvidenceAssessment:
+    if not _unit_interval(threshold):
+        raise ValueError("evidence threshold must be finite and in [0, 1]")
+
+    contradicted = 0.0
+    unresolved = 0.0
+    supported = 0.0
+
+    for item in evidence:
+        item.validate()
+        weight = item.confidence * item.reliability * item.provenance_quality
+        supported += weight * max(item.direction, 0.0)
+        contradicted += weight * max(-item.direction, 0.0)
+        unresolved += weight * (1.0 - abs(item.direction))
+
+    total = contradicted + unresolved + supported
+    if total <= float.fromhex("0x1.0p-52"):
+        probabilities = (1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0)
+    else:
+        probabilities = (contradicted / total, unresolved / total, supported / total)
+
+    support_score = probabilities[2] - probabilities[0]
+    if support_score > threshold:
+        state = EvidenceState.SUPPORTED.value
+    elif support_score < -threshold:
+        state = EvidenceState.CONTRADICTED.value
+    else:
+        state = EvidenceState.UNRESOLVED.value
+
+    confidence = max(probabilities[0], probabilities[2])
+    entropy = -sum(p * math.log2(p) for p in probabilities if p > 0.0)
+    uncertainty = entropy / math.log2(3.0)
+
+    return EvidenceAssessment(
+        state=state,
+        support_score=support_score,
+        confidence=confidence,
+        uncertainty=uncertainty,
+        probabilities=probabilities,
+    )
+
+
+def validate_profile(profile: LUFITProfile, requirements: ClaimRequirements) -> ProfileStatus:
+    if (
+        not math.isfinite(profile.resolution_level)
+        or profile.resolution_level < 0.0
+        or profile.budget_units < 0
+        or not math.isfinite(profile.cutoff)
+        or profile.cutoff < 0.0
+        or not math.isfinite(requirements.required_resolution_level)
+        or requirements.required_resolution_level < 0.0
+        or requirements.estimated_cost_units < 0
+        or not math.isfinite(requirements.regime_value)
+    ):
+        raise ValueError("LUFIT profile and claim requirements must use finite non-negative bounds")
+
+    violations: list[dict[str, Any]] = []
+    if profile.resolution_level < requirements.required_resolution_level:
+        violations.append(
+            {
+                "code": "insufficient_resolution",
+                "available": profile.resolution_level,
+                "required": requirements.required_resolution_level,
+            }
+        )
+    if profile.budget_units < requirements.estimated_cost_units:
+        violations.append(
+            {
+                "code": "budget_exceeded",
+                "available": profile.budget_units,
+                "required": requirements.estimated_cost_units,
+            }
+        )
+    for observable in sorted(requirements.required_observables - profile.observables):
+        violations.append({"code": "missing_observable", "observable": observable})
+    if requirements.method not in profile.methods:
+        violations.append({"code": "method_not_allowed", "method": requirements.method})
+    if abs(requirements.regime_value) > profile.cutoff:
+        violations.append(
+            {
+                "code": "cutoff_exceeded",
+                "cutoff": profile.cutoff,
+                "value": requirements.regime_value,
+            }
+        )
+
+    return ProfileStatus(in_profile=not violations, violations=tuple(violations))
+
+
+def qualify_factual_claim(
+    *,
+    source_class: str,
+    profile_status: ProfileStatus,
+    assessment: EvidenceAssessment,
+) -> str:
+    if not profile_status.in_profile:
+        return ClaimQualification.OUT_OF_PROFILE.value
+    if source_class == SourceClass.SIMULATED.value:
+        return ClaimQualification.SIMULATION_ONLY.value
+    if assessment.state == EvidenceState.SUPPORTED.value:
+        return ClaimQualification.SUPPORTED.value
+    if assessment.state == EvidenceState.CONTRADICTED.value:
+        return ClaimQualification.CONTRADICTED.value
+    return ClaimQualification.UNRESOLVED.value
+
+
+def rag0shot_score(signals: RetrievalSignals) -> float:
+    signals.validate()
+    return (
+        0.40 * signals.semantic
+        + 0.20 * signals.provenance
+        + 0.15 * signals.reliability
+        + 0.15 * signals.graph
+        + 0.10 * signals.temporal
+    )
+
+
+def rank_candidates(candidates: Iterable[tuple[str, RetrievalSignals]]) -> list[tuple[str, float]]:
+    ranked = [(candidate_id, rag0shot_score(signals)) for candidate_id, signals in candidates]
+    return sorted(ranked, key=lambda item: (-item[1], item[0]))
+
+
+def _unit_interval(value: float) -> bool:
+    return math.isfinite(value) and 0.0 <= value <= 1.0

--- a/migi/epistemics.py
+++ b/migi/epistemics.py
@@ -53,6 +53,8 @@ class EvidenceAssessment:
     support_score: float
     confidence: float
     uncertainty: float
+    evidence_weight: float
+    evidence_strength: float
     probabilities: tuple[float, float, float]
 
     def to_dict(self) -> dict[str, Any]:
@@ -61,6 +63,8 @@ class EvidenceAssessment:
             "support_score": self.support_score,
             "confidence": self.confidence,
             "uncertainty": self.uncertainty,
+            "evidence_weight": self.evidence_weight,
+            "evidence_strength": self.evidence_strength,
             "probabilities": {
                 "contradicted": self.probabilities[0],
                 "unresolved": self.probabilities[1],
@@ -191,9 +195,16 @@ class RetrievalSignals:
                 raise ValueError(f"retrieval signal {name} must be finite and in [0, 1]")
 
 
-def evaluate_evidence(evidence: Iterable[EvidenceItem], *, threshold: float = 0.60) -> EvidenceAssessment:
+def evaluate_evidence(
+    evidence: Iterable[EvidenceItem],
+    *,
+    threshold: float = 0.60,
+    reference_weight: float = 1.0,
+) -> EvidenceAssessment:
     if not _unit_interval(threshold):
         raise ValueError("evidence threshold must be finite and in [0, 1]")
+    if not math.isfinite(reference_weight) or reference_weight <= 0.0:
+        raise ValueError("evidence reference_weight must be finite and greater than zero")
 
     contradicted = 0.0
     unresolved = 0.0
@@ -206,11 +217,25 @@ def evaluate_evidence(evidence: Iterable[EvidenceItem], *, threshold: float = 0.
         contradicted += weight * max(-item.direction, 0.0)
         unresolved += weight * (1.0 - abs(item.direction))
 
-    total = contradicted + unresolved + supported
-    if total <= float.fromhex("0x1.0p-52"):
-        probabilities = (1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0)
+    evidence_weight = contradicted + unresolved + supported
+    if evidence_weight <= float.fromhex("0x1.0p-52"):
+        directional_probabilities = (1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0)
     else:
-        probabilities = (contradicted / total, unresolved / total, supported / total)
+        directional_probabilities = (
+            contradicted / evidence_weight,
+            unresolved / evidence_weight,
+            supported / evidence_weight,
+        )
+
+    # Normalizing directional mass alone would turn an arbitrarily weak source
+    # into perfect support or contradiction. Preserve absolute evidence strength
+    # by blending sub-reference evidence toward a uniform ignorance baseline.
+    evidence_strength = min(evidence_weight / reference_weight, 1.0)
+    ignorance = (1.0 - evidence_strength) / 3.0
+    probabilities = tuple(
+        ignorance + evidence_strength * probability
+        for probability in directional_probabilities
+    )
 
     support_score = probabilities[2] - probabilities[0]
     if support_score > threshold:
@@ -229,6 +254,8 @@ def evaluate_evidence(evidence: Iterable[EvidenceItem], *, threshold: float = 0.
         support_score=support_score,
         confidence=confidence,
         uncertainty=uncertainty,
+        evidence_weight=evidence_weight,
+        evidence_strength=evidence_strength,
         probabilities=probabilities,
     )
 
@@ -286,10 +313,10 @@ def qualify_factual_claim(
     profile_status: ProfileStatus,
     assessment: EvidenceAssessment,
 ) -> str:
-    if not profile_status.in_profile:
-        return ClaimQualification.OUT_OF_PROFILE.value
     if source_class == SourceClass.SIMULATED.value:
         return ClaimQualification.SIMULATION_ONLY.value
+    if not profile_status.in_profile:
+        return ClaimQualification.OUT_OF_PROFILE.value
     if assessment.state == EvidenceState.SUPPORTED.value:
         return ClaimQualification.SUPPORTED.value
     if assessment.state == EvidenceState.CONTRADICTED.value:

--- a/tests/test_epistemics.py
+++ b/tests/test_epistemics.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from migi.claim_runtime import VerifiableClaimRuntime
+from migi.epistemics import (
+    ClaimRequirements,
+    EvidenceItem,
+    EvidenceState,
+    LUFITProfile,
+    RetrievalSignals,
+    SFOObservation,
+    evaluate_evidence,
+    rag0shot_score,
+)
+from migi.genesis import GenesisNode
+from migi.models import SourceClass
+
+
+class EpistemicsTests(unittest.TestCase):
+    def _runtime(self, root: Path) -> tuple[GenesisNode, VerifiableClaimRuntime]:
+        node = GenesisNode(root / "genesis.db", allowed_roots=[root])
+        return node, VerifiableClaimRuntime(node.store, node.guard)
+
+    def _profile(self) -> LUFITProfile:
+        return LUFITProfile.create(
+            resolution_level=64.0,
+            budget_units=1_000,
+            observables=["temperature"],
+            methods=["sensor-fusion"],
+            cutoff=10.0,
+        )
+
+    def _requirements(self) -> ClaimRequirements:
+        return ClaimRequirements.create(
+            required_resolution_level=32.0,
+            estimated_cost_units=100,
+            required_observables=["temperature"],
+            method="sensor-fusion",
+            regime_value=2.0,
+        )
+
+    def _evidence(self) -> list[EvidenceItem]:
+        return [
+            EvidenceItem(1.0, 0.98, 0.95, 1.0),
+            EvidenceItem(0.9, 0.90, 0.90, 0.90),
+            EvidenceItem(-1.0, 0.80, 0.20, 0.20),
+        ]
+
+    def test_no_evidence_is_unresolved_and_maximally_uncertain(self):
+        result = evaluate_evidence([], threshold=0.60)
+        self.assertEqual(result.state, EvidenceState.UNRESOLVED.value)
+        self.assertAlmostEqual(result.uncertainty, 1.0)
+
+    def test_observation_to_receipt_to_recall_to_qualified_claim(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            node, runtime = self._runtime(root)
+            assessment = evaluate_evidence(self._evidence(), threshold=0.60)
+            self.assertEqual(assessment.state, EvidenceState.SUPPORTED.value)
+
+            result = runtime.qualify_claim(
+                "engine.temperature.nominal",
+                state_before={"mode": "sampling"},
+                state_after={"mode": "qualified"},
+                observation=SFOObservation(
+                    source_id="sensor-a",
+                    source_class=SourceClass.OBSERVED.value,
+                    value={"temperature_c": 21.5},
+                    confidence=assessment.confidence,
+                    provenance_ref="sensor:a:sample:1",
+                ),
+                evidence=self._evidence(),
+                profile=self._profile(),
+                requirements=self._requirements(),
+                actor_id="tester",
+            )
+
+            self.assertEqual(result["authority"]["tre_logic"], "+1")
+            self.assertEqual(result["execution"]["output"]["qualification"], "supported")
+            self.assertEqual(result["receipt"]["source_class"], SourceClass.DERIVED.value)
+            self.assertTrue(result["chain"]["valid"])
+            self.assertEqual(result["chain"]["checked"], 1)
+
+            recalled = runtime.recall_claim("engine.temperature.nominal")
+            self.assertIsNotNone(recalled)
+            self.assertTrue(recalled["chain"]["valid"])
+            self.assertEqual(recalled["history"][0]["intent"]["action"], "claim.qualify")
+            self.assertEqual(recalled["memories"][0]["facts"]["qualification"], "supported")
+            self.assertEqual(node.store.verify_chain()["checked"], 1)
+
+    def test_simulation_never_silently_becomes_observation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, runtime = self._runtime(root)
+            result = runtime.qualify_claim(
+                "sim.prediction",
+                state_before={"mode": "simulation"},
+                state_after={"mode": "simulation_complete"},
+                observation=SFOObservation(
+                    source_id="physics-sim",
+                    source_class=SourceClass.SIMULATED.value,
+                    value={"temperature_c": 103.0},
+                    confidence=1.0,
+                    provenance_ref="sim:run:1",
+                ),
+                evidence=[EvidenceItem(1.0, 1.0, 1.0, 1.0)],
+                profile=self._profile(),
+                requirements=self._requirements(),
+            )
+
+            self.assertEqual(result["execution"]["output"]["qualification"], "simulation_only")
+            self.assertTrue(result["execution"]["verification"]["simulation_preserved"])
+
+    def test_out_of_profile_claim_is_explicitly_refused(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, runtime = self._runtime(root)
+            profile = LUFITProfile.create(
+                resolution_level=16.0,
+                budget_units=25,
+                observables=["camera"],
+                methods=["vision"],
+                cutoff=1.0,
+            )
+            requirements = ClaimRequirements.create(
+                required_resolution_level=64.0,
+                estimated_cost_units=100,
+                required_observables=["camera", "imu"],
+                method="sensor-fusion",
+                regime_value=2.5,
+            )
+            result = runtime.qualify_claim(
+                "out.of.profile",
+                state_before={},
+                state_after={},
+                observation=SFOObservation(
+                    source_id="camera-a",
+                    source_class=SourceClass.OBSERVED.value,
+                    value={"object": "vehicle"},
+                    confidence=0.95,
+                ),
+                evidence=[EvidenceItem(1.0, 0.95, 0.95, 0.95)],
+                profile=profile,
+                requirements=requirements,
+            )
+
+            output = result["execution"]["output"]
+            self.assertEqual(output["qualification"], "out_of_profile")
+            self.assertEqual(output["profile"]["status"], "out_of_profile")
+            self.assertEqual(len(output["profile"]["violations"]), 5)
+
+    def test_reasoning_without_explicit_scope_holds_and_does_not_execute(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, runtime = self._runtime(root)
+            result = runtime.qualify_claim(
+                "blocked.claim",
+                state_before={},
+                state_after={},
+                observation=SFOObservation(
+                    source_id="sensor-a",
+                    source_class=SourceClass.OBSERVED.value,
+                    value={"x": 1},
+                    confidence=1.0,
+                ),
+                evidence=[EvidenceItem(1.0, 1.0, 1.0, 1.0)],
+                profile=self._profile(),
+                requirements=self._requirements(),
+                consent_scope="unspecified",
+            )
+
+            self.assertEqual(result["authority"]["tre_logic"], "0")
+            self.assertIsNone(result["execution"])
+            self.assertEqual(result["receipt"]["source_class"], SourceClass.PROPOSED.value)
+            self.assertTrue(result["chain"]["valid"])
+
+    def test_provenance_aware_rag0shot_can_beat_similarity_only(self):
+        trusted = RetrievalSignals(
+            semantic=0.82,
+            provenance=1.0,
+            reliability=0.95,
+            graph=0.80,
+            temporal=0.90,
+        )
+        untrusted = RetrievalSignals(
+            semantic=1.0,
+            provenance=0.10,
+            reliability=0.20,
+            graph=0.30,
+            temporal=0.90,
+        )
+
+        self.assertGreater(untrusted.semantic, trusted.semantic)
+        self.assertGreater(rag0shot_score(trusted), rag0shot_score(untrusted))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_epistemics.py
+++ b/tests/test_epistemics.py
@@ -53,6 +53,21 @@ class EpistemicsTests(unittest.TestCase):
         result = evaluate_evidence([], threshold=0.60)
         self.assertEqual(result.state, EvidenceState.UNRESOLVED.value)
         self.assertAlmostEqual(result.uncertainty, 1.0)
+        self.assertEqual(result.evidence_weight, 0.0)
+        self.assertEqual(result.evidence_strength, 0.0)
+
+    def test_arbitrarily_weak_evidence_remains_unresolved(self):
+        result = evaluate_evidence(
+            [EvidenceItem(1.0, 1e-10, 1.0, 1.0)],
+            threshold=0.60,
+        )
+
+        self.assertEqual(result.state, EvidenceState.UNRESOLVED.value)
+        self.assertAlmostEqual(result.evidence_weight, 1e-10)
+        self.assertAlmostEqual(result.evidence_strength, 1e-10)
+        self.assertLess(result.support_score, 0.60)
+        self.assertLess(result.confidence, 0.34)
+        self.assertGreater(result.uncertainty, 0.99)
 
     def test_observation_to_receipt_to_recall_to_qualified_claim(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -80,7 +95,9 @@ class EpistemicsTests(unittest.TestCase):
 
             self.assertEqual(result["authority"]["tre_logic"], "+1")
             self.assertEqual(result["execution"]["output"]["qualification"], "supported")
+            self.assertTrue(result["execution"]["verification"]["factual_claim_verified"])
             self.assertEqual(result["receipt"]["source_class"], SourceClass.DERIVED.value)
+            self.assertTrue(result["receipt"]["metadata"]["verified"])
             self.assertTrue(result["chain"]["valid"])
             self.assertEqual(result["chain"]["checked"], 1)
 
@@ -113,6 +130,43 @@ class EpistemicsTests(unittest.TestCase):
 
             self.assertEqual(result["execution"]["output"]["qualification"], "simulation_only")
             self.assertTrue(result["execution"]["verification"]["simulation_preserved"])
+            self.assertFalse(result["execution"]["verification"]["factual_claim_verified"])
+            self.assertFalse(result["receipt"]["metadata"]["verified"])
+
+    def test_simulation_classification_is_preserved_when_out_of_profile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, runtime = self._runtime(root)
+            profile = LUFITProfile.create(
+                resolution_level=1.0,
+                budget_units=1,
+                observables=[],
+                methods=[],
+                cutoff=0.0,
+            )
+            result = runtime.qualify_claim(
+                "sim.out.of.profile",
+                state_before={"mode": "simulation"},
+                state_after={"mode": "simulation_complete"},
+                observation=SFOObservation(
+                    source_id="physics-sim",
+                    source_class=SourceClass.SIMULATED.value,
+                    value={"temperature_c": 103.0},
+                    confidence=1.0,
+                    provenance_ref="sim:run:out-of-profile",
+                ),
+                evidence=[EvidenceItem(1.0, 1.0, 1.0, 1.0)],
+                profile=profile,
+                requirements=self._requirements(),
+            )
+
+            output = result["execution"]["output"]
+            self.assertEqual(output["qualification"], "simulation_only")
+            self.assertEqual(output["profile"]["status"], "out_of_profile")
+            self.assertTrue(result["execution"]["success"])
+            self.assertTrue(result["execution"]["verification"]["simulation_preserved"])
+            self.assertFalse(result["execution"]["verification"]["factual_claim_verified"])
+            self.assertFalse(result["receipt"]["metadata"]["verified"])
 
     def test_out_of_profile_claim_is_explicitly_refused(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -151,6 +205,8 @@ class EpistemicsTests(unittest.TestCase):
             self.assertEqual(output["qualification"], "out_of_profile")
             self.assertEqual(output["profile"]["status"], "out_of_profile")
             self.assertEqual(len(output["profile"]["violations"]), 5)
+            self.assertFalse(result["execution"]["verification"]["factual_claim_verified"])
+            self.assertFalse(result["receipt"]["metadata"]["verified"])
 
     def test_reasoning_without_explicit_scope_holds_and_does_not_execute(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

This PR turns the LUFIT/SFO architecture into an executable Python vertical slice on top of the current Genesis Node.

### Adds
- `migi.epistemics` with:
  - SFO observation/state records
  - three-state evidence assessment (`+1 / 0 / -1`)
  - provenance/reliability/confidence weighting
  - normalized Shannon-entropy uncertainty
  - executable LUFIT profile checks
  - simulation-only factual boundary
  - provenance-aware RAG0SHOT scoring baseline
- `VerifiableClaimRuntime` composed with the existing `GenesisStore` and `LUFITGuard`
- explicit `claim.qualify` authority scope (`local.reason` / `private.local.reason`)
- derived MIGIReceipts and recallable memory for qualified claims
- architecture documentation

### Invariants tested
- no evidence => unresolved
- simulation cannot silently become factual observation
- out-of-profile claims are explicit
- missing reasoning consent => Hold (`0`) and no execution
- qualified observations produce verifiable receipt-chain history and recall
- provenance-aware RAG0SHOT can outrank similarity-only results when source quality matters

### Architecture boundary
This does not add MCFP/Hex64³ yet. The epistemic core should be benchmarked first so compression work cannot hide correctness failures.

### Next
Generate a fixed ~1,000-claim synthetic benchmark and measure precision/recall/MRR, calibration/Brier score, bad-source retrieval rate, out-of-profile refusal accuracy, latency, and receipt overhead.