### PR TITLE
MIGI-CS-003: 1,000-case verifiable-core benchmark

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -26,6 +26,7 @@ jobs:
           test -f docs/architecture/internal-operating-projects.md
           test -f docs/architecture/repository-roles.md
           test -f docs/architecture/genesis-node-v0.1.md
+          test -f docs/architecture/lufit-sfo-verifiable-core.md
           test -f docs/roadmap/mirror-seed-mvp.md
           test -f docs/adr/README.md
           test -f provenance/dependencies.yaml
@@ -33,7 +34,12 @@ jobs:
           test -f schemas/migi-receipt.v0.json
           test -f pyproject.toml
           test -f migi/genesis.py
+          test -f migi/epistemics.py
+          test -f migi/claim_runtime.py
+          test -f benchmarks/migi_cs_002_benchmark.py
           test -f tests/test_genesis.py
+          test -f tests/test_epistemics.py
+          test -f tests/test_migi_cs_002_benchmark.py
       - name: Validate JSON schemas parse
         run: |
           python -m json.tool schemas/muef-event.v0.json >/dev/null
@@ -41,3 +47,6 @@ jobs:
       - name: Run Genesis Node tests
         run: |
           PYTHONPATH=. python -W error::ResourceWarning -m unittest discover -s tests -v
+      - name: Run MIGI-CS-002 benchmark
+        run: |
+          PYTHONPATH=. python benchmarks/migi_cs_002_benchmark.py --json | tee migi-cs-002-benchmark.json

--- a/benchmarks/MIGI-CS-002-BASELINE.md
+++ b/benchmarks/MIGI-CS-002-BASELINE.md
@@ -1,0 +1,81 @@
+# MIGI-CS-002 Synthetic Benchmark Baseline
+
+Recorded from GitHub Actions run `34171847370` on 2026-09-07.
+
+Environment: Ubuntu 24.04, CPython 3.11.16.
+
+## Scope
+
+This is a deterministic **synthetic contract benchmark**, not a real-world accuracy claim. It tests whether the LUFIT/SFO/RAG0SHOT mechanisms behave as designed under controlled failure modes.
+
+Corpus size: **1,000 cases**
+
+- supported: 200
+- contradicted: 200
+- unresolved: 200
+- out-of-profile: 200
+- simulation-only: 200
+
+Every case also contains a five-candidate retrieval problem with one trusted relevant candidate and adversarial distractors.
+
+## Retrieval baseline
+
+| Metric | Semantic-only | RAG0SHOT |
+|---|---:|---:|
+| Precision@1 | 0.25 | 1.00 |
+| Recall@3 | 1.00 | 1.00 |
+| MRR | 0.625 | 1.00 |
+| Bad-source top-1 rate | 0.75 | 0.00 |
+
+Delta from semantic-only to RAG0SHOT:
+
+- Precision@1: **+0.75**
+- MRR: **+0.375**
+- bad-source top-1 rate: **-0.75**
+
+The corpus intentionally creates a high-semantic / low-provenance distractor in 75% of retrieval cases. These numbers therefore verify the weighting mechanism; they do not establish performance on natural data.
+
+## Claim qualification baseline
+
+| Metric | Result |
+|---|---:|
+| Qualification accuracy | 1.00 |
+| Tre evidence-state accuracy | 1.00 |
+| Multiclass Brier score | 0.0075246251 |
+| Top-class calibration error | 0.0708266667 |
+| Out-of-profile refusal accuracy | 1.00 |
+| Simulation-boundary accuracy | 1.00 |
+
+Pure qualification latency on the CI runner:
+
+- mean: **0.00859 ms**
+- p50: **0.00828 ms**
+- p95: **0.01022 ms**
+
+These latency values are machine-dependent and are recorded only as a reference point, not as a gating threshold.
+
+## Receipt overhead sample
+
+Sample size: **20 real VerifiableClaimRuntime receipts**
+
+- mean receipt size: **716.6 bytes**
+- p95 receipt size: **725 bytes**
+- mean end-to-end qualification + persistence: **9.828 ms**
+- p95 end-to-end: **10.422 ms**
+- receipt chain checked: **20**
+- receipt chain valid: **true**
+
+## Test status
+
+The same CI run completed **24 unit tests successfully** before running the benchmark.
+
+## Next benchmark stage
+
+The next stage must make the benchmark harder and less self-defined:
+
+1. replace part of the synthetic retrieval set with held-out repository/chat artifacts;
+2. add noisy and contradictory multi-source observations;
+3. separate development and test splits before tuning RAG0SHOT weights;
+4. add ablations for provenance, reliability, graph, and temporal terms;
+5. compare against BM25/lexical and embedding baselines when those adapters are available;
+6. keep this synthetic suite as a regression/contract test rather than presenting it as external validation.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible MIGI benchmark suites."""

--- a/benchmarks/migi_cs_002_benchmark.py
+++ b/benchmarks/migi_cs_002_benchmark.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from migi.authority import LUFITGuard
+from migi.claim_runtime import VerifiableClaimRuntime
+from migi.epistemics import (
+    ClaimRequirements,
+    EvidenceItem,
+    LUFITProfile,
+    RetrievalSignals,
+    SFOObservation,
+    evaluate_evidence,
+    qualify_factual_claim,
+    rag0shot_score,
+    validate_profile,
+)
+from migi.models import SourceClass
+from migi.storage import GenesisStore
+
+CORPUS_SIZE = 1000
+RECEIPT_SAMPLE_SIZE = 20
+
+
+@dataclass(frozen=True)
+class RetrievalCandidate:
+    candidate_id: str
+    source_quality: str
+    signals: RetrievalSignals
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    case_id: str
+    expected_qualification: str
+    expected_evidence_state: str
+    observation: SFOObservation
+    evidence: tuple[EvidenceItem, ...]
+    profile: LUFITProfile
+    requirements: ClaimRequirements
+    relevant_candidate_id: str
+    retrieval_candidates: tuple[RetrievalCandidate, ...]
+
+
+def generate_corpus(size: int = CORPUS_SIZE) -> list[BenchmarkCase]:
+    """Generate the fixed synthetic MIGI-CS-002 contract corpus.
+
+    The generator is intentionally deterministic and contains no random state.
+    Five claim regimes repeat evenly: supported, contradicted, unresolved,
+    out-of-profile, and simulation-only. Every case also contains a retrieval
+    problem with one trusted relevant candidate plus distractors.
+    """
+    if size <= 0:
+        raise ValueError("benchmark corpus size must be positive")
+
+    cases: list[BenchmarkCase] = []
+    for index in range(size):
+        regime = index % 5
+        case_id = f"migi-cs-002-{index:04d}"
+
+        in_profile = LUFITProfile.create(
+            resolution_level=1.0,
+            budget_units=100,
+            observables={"sensor", "provenance"},
+            methods={"weighted-evidence"},
+            cutoff=10.0,
+        )
+        normal_requirements = ClaimRequirements.create(
+            required_resolution_level=0.8,
+            estimated_cost_units=50,
+            required_observables={"sensor"},
+            method="weighted-evidence",
+            regime_value=5.0,
+        )
+
+        if regime == 0:
+            expected_qualification = "supported"
+            expected_state = "+1"
+            direction = 1.0
+            source_class = SourceClass.OBSERVED.value
+            profile = in_profile
+            requirements = normal_requirements
+        elif regime == 1:
+            expected_qualification = "contradicted"
+            expected_state = "-1"
+            direction = -1.0
+            source_class = SourceClass.OBSERVED.value
+            profile = in_profile
+            requirements = normal_requirements
+        elif regime == 2:
+            expected_qualification = "unresolved"
+            expected_state = "0"
+            direction = 0.0
+            source_class = SourceClass.OBSERVED.value
+            profile = in_profile
+            requirements = normal_requirements
+        elif regime == 3:
+            expected_qualification = "out_of_profile"
+            expected_state = "+1"
+            direction = 1.0
+            source_class = SourceClass.OBSERVED.value
+            profile = in_profile
+            requirements = ClaimRequirements.create(
+                required_resolution_level=1.2,
+                estimated_cost_units=150,
+                required_observables={"sensor", "spectral"},
+                method="spectral-inversion",
+                regime_value=12.0,
+            )
+        else:
+            expected_qualification = "simulation_only"
+            expected_state = "+1"
+            direction = 1.0
+            source_class = SourceClass.SIMULATED.value
+            profile = in_profile
+            requirements = normal_requirements
+
+        observation = SFOObservation(
+            source_id=f"source-{index % 17:02d}",
+            source_class=source_class,
+            value={"case": case_id, "signal": round(0.5 + (index % 100) / 200.0, 4)},
+            confidence=0.98,
+            provenance_ref=f"receipt:fixture-{index:04d}",
+        )
+        evidence = (
+            EvidenceItem(
+                direction=direction,
+                confidence=0.98,
+                reliability=0.96,
+                provenance_quality=0.95,
+            ),
+        )
+
+        relevant_id = f"{case_id}:trusted"
+        trusted_semantic = 0.86 + ((index % 7) - 3) * 0.005
+        # On one quarter of cases semantic-only gets the trusted source right;
+        # otherwise the low-provenance distractor is deliberately more similar.
+        seductive_semantic = trusted_semantic - 0.02 if index % 4 == 0 else trusted_semantic + 0.08
+        retrieval_candidates = (
+            RetrievalCandidate(
+                candidate_id=relevant_id,
+                source_quality="trusted",
+                signals=RetrievalSignals(
+                    semantic=trusted_semantic,
+                    provenance=0.95,
+                    reliability=0.96,
+                    graph=0.85,
+                    temporal=0.80,
+                ),
+            ),
+            RetrievalCandidate(
+                candidate_id=f"{case_id}:seductive-untrusted",
+                source_quality="bad",
+                signals=RetrievalSignals(
+                    semantic=min(seductive_semantic, 0.99),
+                    provenance=0.05,
+                    reliability=0.10,
+                    graph=0.30,
+                    temporal=0.90,
+                ),
+            ),
+            RetrievalCandidate(
+                candidate_id=f"{case_id}:medium",
+                source_quality="medium",
+                signals=RetrievalSignals(
+                    semantic=0.63,
+                    provenance=0.60,
+                    reliability=0.65,
+                    graph=0.55,
+                    temporal=0.60,
+                ),
+            ),
+            RetrievalCandidate(
+                candidate_id=f"{case_id}:stale",
+                source_quality="medium",
+                signals=RetrievalSignals(
+                    semantic=0.58,
+                    provenance=0.80,
+                    reliability=0.75,
+                    graph=0.45,
+                    temporal=0.10,
+                ),
+            ),
+            RetrievalCandidate(
+                candidate_id=f"{case_id}:noise",
+                source_quality="bad",
+                signals=RetrievalSignals(
+                    semantic=0.30,
+                    provenance=0.20,
+                    reliability=0.20,
+                    graph=0.15,
+                    temporal=0.70,
+                ),
+            ),
+        )
+
+        cases.append(
+            BenchmarkCase(
+                case_id=case_id,
+                expected_qualification=expected_qualification,
+                expected_evidence_state=expected_state,
+                observation=observation,
+                evidence=evidence,
+                profile=profile,
+                requirements=requirements,
+                relevant_candidate_id=relevant_id,
+                retrieval_candidates=retrieval_candidates,
+            )
+        )
+    return cases
+
+
+def _rank_semantic(case: BenchmarkCase) -> list[RetrievalCandidate]:
+    return sorted(
+        case.retrieval_candidates,
+        key=lambda candidate: (-candidate.signals.semantic, candidate.candidate_id),
+    )
+
+
+def _rank_rag0shot(case: BenchmarkCase) -> list[RetrievalCandidate]:
+    return sorted(
+        case.retrieval_candidates,
+        key=lambda candidate: (-rag0shot_score(candidate.signals), candidate.candidate_id),
+    )
+
+
+def _retrieval_metrics(cases: list[BenchmarkCase], ranker) -> dict[str, float]:
+    reciprocal_ranks: list[float] = []
+    top1 = 0
+    recall_at_3 = 0
+    bad_top1 = 0
+
+    for case in cases:
+        ranking = ranker(case)
+        ids = [candidate.candidate_id for candidate in ranking]
+        position = ids.index(case.relevant_candidate_id) + 1
+        reciprocal_ranks.append(1.0 / position)
+        top1 += position == 1
+        recall_at_3 += position <= 3
+        bad_top1 += ranking[0].source_quality == "bad"
+
+    count = len(cases)
+    return {
+        "precision_at_1": top1 / count,
+        "recall_at_3": recall_at_3 / count,
+        "mrr": statistics.fmean(reciprocal_ranks),
+        "bad_source_top1_rate": bad_top1 / count,
+    }
+
+
+def _multiclass_brier(probabilities: tuple[float, float, float], expected_state: str) -> float:
+    state_index = {"-1": 0, "0": 1, "+1": 2}[expected_state]
+    target = [0.0, 0.0, 0.0]
+    target[state_index] = 1.0
+    return sum((probabilities[index] - target[index]) ** 2 for index in range(3))
+
+
+def _qualification_metrics(cases: list[BenchmarkCase]) -> dict[str, Any]:
+    correct = 0
+    state_correct = 0
+    brier_scores: list[float] = []
+    confidences: list[float] = []
+    correctness: list[float] = []
+    out_profile_total = 0
+    out_profile_correct = 0
+    simulation_total = 0
+    simulation_correct = 0
+    latencies_ms: list[float] = []
+
+    for case in cases:
+        started = time.perf_counter()
+        assessment = evaluate_evidence(case.evidence)
+        profile_status = validate_profile(case.profile, case.requirements)
+        qualification = qualify_factual_claim(
+            source_class=case.observation.source_class,
+            profile_status=profile_status,
+            assessment=assessment,
+        )
+        latencies_ms.append((time.perf_counter() - started) * 1000.0)
+
+        is_correct = qualification == case.expected_qualification
+        correct += is_correct
+        state_correct += assessment.state == case.expected_evidence_state
+
+        if case.expected_qualification in {"supported", "contradicted", "unresolved"}:
+            brier_scores.append(_multiclass_brier(assessment.probabilities, case.expected_evidence_state))
+            predicted_confidence = max(assessment.probabilities)
+            confidences.append(predicted_confidence)
+            correctness.append(1.0 if assessment.state == case.expected_evidence_state else 0.0)
+
+        if case.expected_qualification == "out_of_profile":
+            out_profile_total += 1
+            out_profile_correct += qualification == "out_of_profile"
+        if case.expected_qualification == "simulation_only":
+            simulation_total += 1
+            simulation_correct += qualification == "simulation_only"
+
+    return {
+        "qualification_accuracy": correct / len(cases),
+        "evidence_state_accuracy": state_correct / len(cases),
+        "multiclass_brier": statistics.fmean(brier_scores),
+        "top_class_calibration_error": abs(statistics.fmean(confidences) - statistics.fmean(correctness)),
+        "out_of_profile_refusal_accuracy": out_profile_correct / out_profile_total,
+        "simulation_boundary_accuracy": simulation_correct / simulation_total,
+        "latency_ms": {
+            "p50": _percentile(latencies_ms, 0.50),
+            "p95": _percentile(latencies_ms, 0.95),
+            "mean": statistics.fmean(latencies_ms),
+        },
+    }
+
+
+def _receipt_metrics(cases: list[BenchmarkCase], sample_size: int = RECEIPT_SAMPLE_SIZE) -> dict[str, Any]:
+    selected = cases[: max(1, min(sample_size, len(cases)))]
+    receipt_bytes: list[int] = []
+    execution_ms: list[float] = []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        store = GenesisStore(root / "benchmark.db")
+        guard = LUFITGuard([root])
+        runtime = VerifiableClaimRuntime(store, guard)
+
+        for case in selected:
+            started = time.perf_counter()
+            result = runtime.qualify_claim(
+                case.case_id,
+                state_before={"phase": "before"},
+                state_after={"phase": "after"},
+                observation=case.observation,
+                evidence=case.evidence,
+                profile=case.profile,
+                requirements=case.requirements,
+            )
+            execution_ms.append((time.perf_counter() - started) * 1000.0)
+            encoded = json.dumps(result["receipt"], sort_keys=True, separators=(",", ":")).encode("utf-8")
+            receipt_bytes.append(len(encoded))
+
+        chain = store.verify_chain()
+
+    return {
+        "sample_size": len(selected),
+        "mean_receipt_bytes": statistics.fmean(receipt_bytes),
+        "p95_receipt_bytes": _percentile([float(value) for value in receipt_bytes], 0.95),
+        "mean_end_to_end_ms": statistics.fmean(execution_ms),
+        "p95_end_to_end_ms": _percentile(execution_ms, 0.95),
+        "receipt_chain_valid": bool(chain["valid"]),
+        "receipt_chain_checked": int(chain["checked"]),
+    }
+
+
+def run_benchmark(size: int = CORPUS_SIZE, receipt_sample_size: int = RECEIPT_SAMPLE_SIZE) -> dict[str, Any]:
+    cases = generate_corpus(size)
+    semantic = _retrieval_metrics(cases, _rank_semantic)
+    rag0shot = _retrieval_metrics(cases, _rank_rag0shot)
+    qualification = _qualification_metrics(cases)
+    receipts = _receipt_metrics(cases, receipt_sample_size)
+
+    return {
+        "benchmark": "MIGI-CS-002",
+        "corpus": {
+            "size": len(cases),
+            "regimes": {
+                label: sum(case.expected_qualification == label for case in cases)
+                for label in (
+                    "supported",
+                    "contradicted",
+                    "unresolved",
+                    "out_of_profile",
+                    "simulation_only",
+                )
+            },
+            "synthetic": True,
+            "deterministic": True,
+        },
+        "retrieval": {
+            "semantic_only": semantic,
+            "rag0shot": rag0shot,
+            "delta": {
+                "precision_at_1": rag0shot["precision_at_1"] - semantic["precision_at_1"],
+                "mrr": rag0shot["mrr"] - semantic["mrr"],
+                "bad_source_top1_rate": rag0shot["bad_source_top1_rate"] - semantic["bad_source_top1_rate"],
+            },
+        },
+        "qualification": qualification,
+        "receipt_overhead": receipts,
+        "interpretation": (
+            "Synthetic contract benchmark only. It tests the intended architecture under controlled failure modes; "
+            "it is not evidence of real-world generalization or superiority."
+        ),
+    }
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return math.nan
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * quantile
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return ordered[lower]
+    fraction = index - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def _human_report(result: dict[str, Any]) -> str:
+    retrieval = result["retrieval"]
+    qualification = result["qualification"]
+    receipts = result["receipt_overhead"]
+    return "\n".join(
+        [
+            f"{result['benchmark']} synthetic benchmark ({result['corpus']['size']} cases)",
+            f"semantic P@1={retrieval['semantic_only']['precision_at_1']:.3f} MRR={retrieval['semantic_only']['mrr']:.3f} bad-top1={retrieval['semantic_only']['bad_source_top1_rate']:.3f}",
+            f"RAG0SHOT P@1={retrieval['rag0shot']['precision_at_1']:.3f} MRR={retrieval['rag0shot']['mrr']:.3f} bad-top1={retrieval['rag0shot']['bad_source_top1_rate']:.3f}",
+            f"qualification accuracy={qualification['qualification_accuracy']:.3f} Brier={qualification['multiclass_brier']:.6f} calibration-error={qualification['top_class_calibration_error']:.6f}",
+            f"out-of-profile refusal={qualification['out_of_profile_refusal_accuracy']:.3f} simulation-boundary={qualification['simulation_boundary_accuracy']:.3f}",
+            f"pure qualification latency p50={qualification['latency_ms']['p50']:.4f}ms p95={qualification['latency_ms']['p95']:.4f}ms",
+            f"receipt sample={receipts['sample_size']} mean-bytes={receipts['mean_receipt_bytes']:.1f} end-to-end p95={receipts['p95_end_to_end_ms']:.3f}ms chain-valid={receipts['receipt_chain_valid']}",
+            result["interpretation"],
+        ]
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the deterministic MIGI-CS-002 benchmark")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of the human summary")
+    parser.add_argument("--size", type=int, default=CORPUS_SIZE)
+    parser.add_argument("--receipt-sample", type=int, default=RECEIPT_SAMPLE_SIZE)
+    args = parser.parse_args()
+
+    result = run_benchmark(args.size, args.receipt_sample)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(_human_report(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_migi_cs_002_benchmark.py
+++ b/tests/test_migi_cs_002_benchmark.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import unittest
+
+from benchmarks.migi_cs_002_benchmark import generate_corpus, run_benchmark
+
+
+class MIGICS002BenchmarkTests(unittest.TestCase):
+    def test_corpus_is_fixed_and_balanced(self):
+        cases = generate_corpus(1000)
+        self.assertEqual(len(cases), 1000)
+        counts = {
+            label: sum(case.expected_qualification == label for case in cases)
+            for label in (
+                "supported",
+                "contradicted",
+                "unresolved",
+                "out_of_profile",
+                "simulation_only",
+            )
+        }
+        self.assertEqual(
+            counts,
+            {
+                "supported": 200,
+                "contradicted": 200,
+                "unresolved": 200,
+                "out_of_profile": 200,
+                "simulation_only": 200,
+            },
+        )
+
+    def test_benchmark_exposes_provenance_ranking_difference(self):
+        result = run_benchmark(1000, receipt_sample_size=5)
+        semantic = result["retrieval"]["semantic_only"]
+        rag0shot = result["retrieval"]["rag0shot"]
+
+        self.assertAlmostEqual(semantic["precision_at_1"], 0.25)
+        self.assertAlmostEqual(semantic["mrr"], 0.625)
+        self.assertAlmostEqual(semantic["bad_source_top1_rate"], 0.75)
+        self.assertAlmostEqual(rag0shot["precision_at_1"], 1.0)
+        self.assertAlmostEqual(rag0shot["mrr"], 1.0)
+        self.assertAlmostEqual(rag0shot["bad_source_top1_rate"], 0.0)
+        self.assertAlmostEqual(rag0shot["recall_at_3"], 1.0)
+
+    def test_claim_qualification_and_boundaries_are_measured(self):
+        result = run_benchmark(1000, receipt_sample_size=5)
+        metrics = result["qualification"]
+
+        self.assertAlmostEqual(metrics["qualification_accuracy"], 1.0)
+        self.assertAlmostEqual(metrics["evidence_state_accuracy"], 1.0)
+        self.assertLess(metrics["multiclass_brier"], 0.02)
+        self.assertLess(metrics["top_class_calibration_error"], 0.10)
+        self.assertAlmostEqual(metrics["out_of_profile_refusal_accuracy"], 1.0)
+        self.assertAlmostEqual(metrics["simulation_boundary_accuracy"], 1.0)
+
+    def test_receipt_sample_uses_real_chain(self):
+        result = run_benchmark(25, receipt_sample_size=5)
+        receipts = result["receipt_overhead"]
+        self.assertEqual(receipts["sample_size"], 5)
+        self.assertTrue(receipts["receipt_chain_valid"])
+        self.assertEqual(receipts["receipt_chain_checked"], 5)
+        self.assertGreater(receipts["mean_receipt_bytes"], 0)
+        self.assertGreater(receipts["mean_end_to_end_ms"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a deterministic 1,000-case synthetic benchmark for the merged MIGI-CS-002 LUFIT/SFO core.

### Corpus
- 1,000 fixed cases, no random state
- 200 supported observations
- 200 contradicted observations
- 200 unresolved observations
- 200 out-of-profile claims
- 200 simulation-only claims
- each case also includes a 5-candidate retrieval problem with a trusted relevant source and adversarial distractors

### Metrics
- semantic-only vs provenance-aware RAG0SHOT Precision@1, Recall@3, MRR
- bad-source top-1 rate
- claim qualification accuracy
- Tre evidence-state accuracy
- multiclass Brier score
- top-class calibration error
- out-of-profile refusal accuracy
- simulation-boundary accuracy
- pure qualification p50/p95 latency
- real Genesis receipt size and end-to-end timing on a sampled chain
- receipt-chain verification

### First CI baseline
GitHub Actions run `34171847370` passed all 24 tests and produced:

| Metric | Semantic-only | RAG0SHOT |
|---|---:|---:|
| Precision@1 | 0.25 | 1.00 |
| Recall@3 | 1.00 | 1.00 |
| MRR | 0.625 | 1.00 |
| Bad-source top-1 rate | 0.75 | 0.00 |

Claim/evidence metrics:
- qualification accuracy: 1.00
- evidence-state accuracy: 1.00
- multiclass Brier: 0.0075246251
- calibration error: 0.0708266667
- out-of-profile refusal accuracy: 1.00
- simulation-boundary accuracy: 1.00

Receipt sample (20):
- mean receipt size: 716.6 bytes
- p95 receipt size: 725 bytes
- mean end-to-end: 9.828 ms
- p95 end-to-end: 10.422 ms
- receipt chain valid: true

The exact baseline is recorded in `benchmarks/MIGI-CS-002-BASELINE.md`.

### Interpretation boundary
The synthetic retrieval cases intentionally make a high-semantic/low-provenance distractor rank first 75% of the time under semantic-only scoring. The benchmark verifies that the provenance-aware weighting changes ranking as designed; it is **not evidence of real-world generalization or superiority**.

### CI
The quality gate runs the full unit suite and emits the benchmark as machine-readable JSON.

### Next after this benchmark
Replace part of the synthetic corpus with held-out real repository/chat artifacts and noisy sensor-style observations, then tune weights only on a separate development split. Add ablations so each provenance/reliability/graph/temporal term has to earn its place.